### PR TITLE
feat(proxy): implement initial OpenAI-compatible proxy endpoints (#11)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -53,10 +53,68 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "axum"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b52af3cb4058c895d37317bb27508dccc8e5f2d39454016b297bf4a400597b8"
+dependencies = [
+ "axum-core",
+ "bytes",
+ "form_urlencoded",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde_core",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
 
 [[package]]
 name = "base64"
@@ -545,6 +603,86 @@ dependencies = [
 ]
 
 [[package]]
+name = "http"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
+dependencies = [
+ "bytes",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+dependencies = [
+ "bytes",
+ "http",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "httparse"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "hyper"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "http",
+ "http-body",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
+dependencies = [
+ "bytes",
+ "http",
+ "http-body",
+ "hyper",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
+]
+
+[[package]]
 name = "iana-time-zone"
 version = "0.1.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -783,6 +921,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
+name = "matchit"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
+
+[[package]]
 name = "md-5"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -797,6 +941,12 @@ name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "mio"
@@ -965,6 +1115,18 @@ dependencies = [
 [[package]]
 name = "penny-proxy"
 version = "0.1.0"
+dependencies = [
+ "axum",
+ "chrono",
+ "penny-providers",
+ "penny-types",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
+ "tokio",
+ "tower",
+ "uuid",
+]
 
 [[package]]
 name = "penny-store"
@@ -1318,6 +1480,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_path_to_error"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
+dependencies = [
+ "itoa",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
 name = "serde_spanned"
 version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1653,6 +1826,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "sync_wrapper"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+
+[[package]]
 name = "synstructure"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1834,6 +2013,34 @@ name = "toml_write"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
+
+[[package]]
+name = "tower"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
+
+[[package]]
+name = "tower-service"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracing"

--- a/crates/penny-providers/src/lib.rs
+++ b/crates/penny-providers/src/lib.rs
@@ -16,6 +16,9 @@ pub trait ProviderAdapter: Send + Sync {
     async fn send(&self, req: NormalizedRequest) -> Result<ProviderResponse, ProviderError>;
     fn provider_id(&self) -> &str;
     fn supports_model(&self, model: &str) -> bool;
+    fn stream_response_lines(&self, _req: &NormalizedRequest) -> Option<Vec<String>> {
+        None
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -171,6 +174,10 @@ impl ProviderAdapter for MockProvider {
 
     fn supports_model(&self, model: &str) -> bool {
         self.config.supported_models.iter().any(|m| m == model)
+    }
+
+    fn stream_response_lines(&self, req: &NormalizedRequest) -> Option<Vec<String>> {
+        Some(self.stream_sse_lines(req))
     }
 }
 

--- a/crates/penny-proxy/Cargo.toml
+++ b/crates/penny-proxy/Cargo.toml
@@ -5,4 +5,16 @@ edition = "2021"
 publish = false
 
 [dependencies]
+axum = "0.8"
+chrono = { version = "0.4", features = ["serde"] }
+penny-providers = { path = "../penny-providers" }
+penny-types = { path = "../penny-types" }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+thiserror = "1"
+tokio = { version = "1", features = ["net", "rt"] }
+uuid = { version = "1", features = ["serde", "v7"] }
 
+[dev-dependencies]
+tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
+tower = { version = "0.5", features = ["util"] }

--- a/crates/penny-proxy/src/lib.rs
+++ b/crates/penny-proxy/src/lib.rs
@@ -1,1 +1,346 @@
 //! Proxy plane implementation for PennyPrompt.
+
+use std::{net::SocketAddr, sync::Arc};
+
+use axum::{
+    extract::{Json, Request, State},
+    http::{header, HeaderValue, StatusCode},
+    middleware::{self, Next},
+    response::{IntoResponse, Response},
+    routing::{get, post},
+    Extension, Router,
+};
+use chrono::Utc;
+use penny_providers::{MockProvider, MockProviderConfig, ProviderAdapter, ProviderError};
+use penny_types::{NormalizedRequest, ResponseBody};
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
+use thiserror::Error;
+use tokio::net::TcpListener;
+use uuid::Uuid;
+
+pub const DEFAULT_PROXY_BIND: &str = "127.0.0.1:8585";
+const REQUEST_ID_HEADER: &str = "x-penny-request-id";
+
+#[derive(Debug, Error)]
+pub enum ProxyError {
+    #[error("address parse error: {0}")]
+    AddressParse(#[from] std::net::AddrParseError),
+    #[error("io error: {0}")]
+    Io(#[from] std::io::Error),
+}
+
+#[derive(Clone)]
+pub struct ProxyState {
+    provider: Arc<dyn ProviderAdapter>,
+    models: Vec<String>,
+    default_project_id: String,
+    default_session_id: String,
+}
+
+impl ProxyState {
+    pub fn with_provider(provider: Arc<dyn ProviderAdapter>, models: Vec<String>) -> Self {
+        Self {
+            provider,
+            models,
+            default_project_id: "default".to_string(),
+            default_session_id: "session-auto".to_string(),
+        }
+    }
+
+    pub fn mock_default() -> Self {
+        let mock = MockProvider::new(MockProviderConfig::default());
+        let models = mock.config().supported_models.clone();
+        Self::with_provider(Arc::new(mock), models)
+    }
+}
+
+#[derive(Debug, Clone)]
+struct RequestContext {
+    request_id: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct ChatCompletionsRequest {
+    model: String,
+    #[serde(default)]
+    messages: Value,
+    #[serde(default)]
+    stream: bool,
+}
+
+#[derive(Debug, Serialize)]
+struct ApiError {
+    error: ApiErrorDetail,
+}
+
+#[derive(Debug, Serialize)]
+struct ApiErrorDetail {
+    code: &'static str,
+    message: String,
+}
+
+pub fn build_router(state: ProxyState) -> Router {
+    Router::new()
+        .route("/v1/chat/completions", post(post_chat_completions))
+        .route("/v1/models", get(get_models))
+        .with_state(Arc::new(state))
+        .layer(middleware::from_fn(request_id_middleware))
+}
+
+pub async fn serve_default() -> Result<(), ProxyError> {
+    serve(DEFAULT_PROXY_BIND).await
+}
+
+pub async fn serve(bind: &str) -> Result<(), ProxyError> {
+    let addr: SocketAddr = bind.parse()?;
+    let listener = TcpListener::bind(addr).await?;
+    let app = build_router(ProxyState::mock_default());
+    axum::serve(listener, app).await?;
+    Ok(())
+}
+
+async fn request_id_middleware(mut req: Request, next: Next) -> Response {
+    let request_id = Uuid::now_v7().to_string();
+    req.extensions_mut().insert(RequestContext {
+        request_id: request_id.clone(),
+    });
+    let mut response = next.run(req).await;
+    if let Ok(value) = HeaderValue::from_str(&request_id) {
+        response.headers_mut().insert(REQUEST_ID_HEADER, value);
+    }
+    response
+}
+
+async fn post_chat_completions(
+    State(state): State<Arc<ProxyState>>,
+    Extension(ctx): Extension<RequestContext>,
+    Json(payload): Json<ChatCompletionsRequest>,
+) -> Response {
+    if let Err(message) = validate_chat_request(&payload) {
+        return error_response(StatusCode::BAD_REQUEST, "invalid_request", message);
+    }
+
+    let normalized = NormalizedRequest {
+        id: ctx.request_id.clone(),
+        project_id: state.default_project_id.clone(),
+        session_id: state.default_session_id.clone(),
+        model_requested: payload.model.clone(),
+        model_resolved: payload.model.clone(),
+        provider_id: state.provider.provider_id().to_string(),
+        messages: payload.messages.clone(),
+        stream: payload.stream,
+        estimated_input_tokens: 0,
+        estimated_output_tokens: 0,
+        timestamp: Utc::now(),
+    };
+
+    let provider_response = match state.provider.send(normalized.clone()).await {
+        Ok(response) => response,
+        Err(ProviderError::UnsupportedModel(model)) => {
+            return error_response(
+                StatusCode::BAD_REQUEST,
+                "unsupported_model",
+                format!("model `{model}` is not configured in the active provider"),
+            );
+        }
+    };
+
+    let status = StatusCode::from_u16(provider_response.status).unwrap_or(StatusCode::OK);
+    match provider_response.body {
+        ResponseBody::Complete(value) => (status, Json(value)).into_response(),
+        ResponseBody::Stream(_) => {
+            if let Some(lines) = state.provider.stream_response_lines(&normalized) {
+                let mut response = (status, lines.concat()).into_response();
+                response.headers_mut().insert(
+                    header::CONTENT_TYPE,
+                    HeaderValue::from_static("text/event-stream; charset=utf-8"),
+                );
+                response
+            } else {
+                error_response(
+                    StatusCode::NOT_IMPLEMENTED,
+                    "streaming_not_supported",
+                    "provider reported stream mode but no stream payload is available".to_string(),
+                )
+            }
+        }
+    }
+}
+
+async fn get_models(State(state): State<Arc<ProxyState>>) -> Json<Value> {
+    let data: Vec<Value> = state
+        .models
+        .iter()
+        .map(|model_id| {
+            json!({
+                "id": model_id,
+                "object": "model",
+                "owned_by": state.provider.provider_id()
+            })
+        })
+        .collect();
+
+    Json(json!({
+        "object": "list",
+        "data": data
+    }))
+}
+
+fn validate_chat_request(payload: &ChatCompletionsRequest) -> Result<(), String> {
+    if payload.model.trim().is_empty() {
+        return Err("field `model` must not be empty".to_string());
+    }
+
+    let Some(messages) = payload.messages.as_array() else {
+        return Err("field `messages` must be an array".to_string());
+    };
+
+    if messages.is_empty() {
+        return Err("field `messages` must contain at least one message".to_string());
+    }
+
+    Ok(())
+}
+
+fn error_response(status: StatusCode, code: &'static str, message: String) -> Response {
+    (
+        status,
+        Json(json!(ApiError {
+            error: ApiErrorDetail { code, message }
+        })),
+    )
+        .into_response()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::{
+        body::{to_bytes, Body},
+        http::Request,
+    };
+    use tower::ServiceExt;
+
+    fn app() -> Router {
+        build_router(ProxyState::mock_default())
+    }
+
+    #[tokio::test]
+    async fn post_chat_completions_passes_through_mock_provider() {
+        let request = Request::builder()
+            .method("POST")
+            .uri("/v1/chat/completions")
+            .header(header::CONTENT_TYPE, "application/json")
+            .body(Body::from(
+                json!({
+                    "model": "claude-sonnet-4-6",
+                    "messages": [{"role":"user","content":"hello"}]
+                })
+                .to_string(),
+            ))
+            .expect("build request");
+
+        let response = app().oneshot(request).await.expect("response");
+        assert_eq!(response.status(), StatusCode::OK);
+        assert!(response.headers().get(REQUEST_ID_HEADER).is_some());
+
+        let body = to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("read body");
+        let json_body: Value = serde_json::from_slice(&body).expect("json body");
+        assert_eq!(
+            json_body["choices"][0]["message"]["content"],
+            "Mock provider deterministic response."
+        );
+    }
+
+    #[tokio::test]
+    async fn post_chat_completions_invalid_payload_fails_clearly() {
+        let request = Request::builder()
+            .method("POST")
+            .uri("/v1/chat/completions")
+            .header(header::CONTENT_TYPE, "application/json")
+            .body(Body::from(
+                json!({
+                    "model": "",
+                    "messages": []
+                })
+                .to_string(),
+            ))
+            .expect("build request");
+
+        let response = app().oneshot(request).await.expect("response");
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        assert!(response.headers().get(REQUEST_ID_HEADER).is_some());
+
+        let body = to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("read body");
+        let json_body: Value = serde_json::from_slice(&body).expect("json body");
+        assert_eq!(json_body["error"]["code"], "invalid_request");
+        assert_eq!(
+            json_body["error"]["message"],
+            "field `model` must not be empty"
+        );
+    }
+
+    #[tokio::test]
+    async fn get_models_returns_openai_compatible_model_list() {
+        let request = Request::builder()
+            .method("GET")
+            .uri("/v1/models")
+            .body(Body::empty())
+            .expect("build request");
+
+        let response = app().oneshot(request).await.expect("response");
+        assert_eq!(response.status(), StatusCode::OK);
+        assert!(response.headers().get(REQUEST_ID_HEADER).is_some());
+
+        let body = to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("read body");
+        let json_body: Value = serde_json::from_slice(&body).expect("json body");
+        assert_eq!(json_body["object"], "list");
+        assert!(json_body["data"]
+            .as_array()
+            .expect("array data")
+            .iter()
+            .any(|item| item["id"] == "claude-sonnet-4-6"));
+    }
+
+    #[tokio::test]
+    async fn streaming_requests_return_sse_payload() {
+        let request = Request::builder()
+            .method("POST")
+            .uri("/v1/chat/completions")
+            .header(header::CONTENT_TYPE, "application/json")
+            .body(Body::from(
+                json!({
+                    "model": "claude-sonnet-4-6",
+                    "messages": [{"role":"user","content":"stream please"}],
+                    "stream": true
+                })
+                .to_string(),
+            ))
+            .expect("build request");
+
+        let response = app().oneshot(request).await.expect("response");
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(
+            response
+                .headers()
+                .get(header::CONTENT_TYPE)
+                .and_then(|v| v.to_str().ok()),
+            Some("text/event-stream; charset=utf-8")
+        );
+        assert!(response.headers().get(REQUEST_ID_HEADER).is_some());
+
+        let body = to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("read body");
+        let text = String::from_utf8(body.to_vec()).expect("utf8 body");
+        assert!(text.contains("data: [DONE]"));
+        assert!(text.contains("\"usage\""));
+    }
+}


### PR DESCRIPTION
- add proxy router with POST /v1/chat/completions and GET /v1/models
- generate and attach X-Penny-Request-Id on every response
- pass requests through MockProvider with clear validation errors
- support deterministic streaming path via SSE payload lines
- add endpoint tests for valid, invalid, models list, and streaming flows