### PR TITLE
feat(proxy): add request normalization and SQLite persistence pipelin…

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1118,10 +1118,13 @@ version = "0.1.0"
 dependencies = [
  "axum",
  "chrono",
+ "penny-cost",
  "penny-providers",
+ "penny-store",
  "penny-types",
  "serde",
  "serde_json",
+ "sqlx",
  "thiserror 1.0.69",
  "tokio",
  "tower",

--- a/crates/penny-proxy/Cargo.toml
+++ b/crates/penny-proxy/Cargo.toml
@@ -7,7 +7,9 @@ publish = false
 [dependencies]
 axum = "0.8"
 chrono = { version = "0.4", features = ["serde"] }
+penny-cost = { path = "../penny-cost" }
 penny-providers = { path = "../penny-providers" }
+penny-store = { path = "../penny-store" }
 penny-types = { path = "../penny-types" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
@@ -16,5 +18,6 @@ tokio = { version = "1", features = ["net", "rt"] }
 uuid = { version = "1", features = ["serde", "v7"] }
 
 [dev-dependencies]
+sqlx = { version = "0.8", features = ["runtime-tokio-rustls", "sqlite"] }
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 tower = { version = "0.5", features = ["util"] }

--- a/crates/penny-proxy/src/lib.rs
+++ b/crates/penny-proxy/src/lib.rs
@@ -11,8 +11,10 @@ use axum::{
     Extension, Router,
 };
 use chrono::Utc;
+use penny_cost::estimate_tokens;
 use penny_providers::{MockProvider, MockProviderConfig, ProviderAdapter, ProviderError};
-use penny_types::{NormalizedRequest, ResponseBody};
+use penny_store::{NewRequest, ProjectRepo, RequestRepo, SqliteStore, UsageRecord};
+use penny_types::{NormalizedRequest, ResponseBody, UsageSource};
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 use thiserror::Error;
@@ -33,6 +35,7 @@ pub enum ProxyError {
 #[derive(Clone)]
 pub struct ProxyState {
     provider: Arc<dyn ProviderAdapter>,
+    store: Option<SqliteStore>,
     models: Vec<String>,
     default_project_id: String,
     default_session_id: String,
@@ -42,10 +45,16 @@ impl ProxyState {
     pub fn with_provider(provider: Arc<dyn ProviderAdapter>, models: Vec<String>) -> Self {
         Self {
             provider,
+            store: None,
             models,
             default_project_id: "default".to_string(),
             default_session_id: "session-auto".to_string(),
         }
+    }
+
+    pub fn with_store(mut self, store: SqliteStore) -> Self {
+        self.store = Some(store);
+        self
     }
 
     pub fn mock_default() -> Self {
@@ -78,6 +87,14 @@ struct ApiError {
 struct ApiErrorDetail {
     code: &'static str,
     message: String,
+}
+
+#[derive(Debug, Clone)]
+struct NormalizedUsage {
+    input_tokens: u64,
+    output_tokens: u64,
+    source: UsageSource,
+    pricing_snapshot: Value,
 }
 
 pub fn build_router(state: ProxyState) -> Router {
@@ -121,19 +138,7 @@ async fn post_chat_completions(
         return error_response(StatusCode::BAD_REQUEST, "invalid_request", message);
     }
 
-    let normalized = NormalizedRequest {
-        id: ctx.request_id.clone(),
-        project_id: state.default_project_id.clone(),
-        session_id: state.default_session_id.clone(),
-        model_requested: payload.model.clone(),
-        model_resolved: payload.model.clone(),
-        provider_id: state.provider.provider_id().to_string(),
-        messages: payload.messages.clone(),
-        stream: payload.stream,
-        estimated_input_tokens: 0,
-        estimated_output_tokens: 0,
-        timestamp: Utc::now(),
-    };
+    let normalized = normalize_chat_request(&ctx, &state, &payload);
 
     let provider_response = match state.provider.send(normalized.clone()).await {
         Ok(response) => response,
@@ -146,11 +151,33 @@ async fn post_chat_completions(
         }
     };
 
-    let status = StatusCode::from_u16(provider_response.status).unwrap_or(StatusCode::OK);
+    let status = StatusCode::from_u16(provider_response.status).unwrap_or(StatusCode::BAD_GATEWAY);
     match provider_response.body {
-        ResponseBody::Complete(value) => (status, Json(value)).into_response(),
+        ResponseBody::Complete(value) => {
+            let usage = provider_usage_from_completion(&value)
+                .unwrap_or_else(|| estimated_usage_from_request(&normalized));
+            if let Err(message) = persist_request_and_usage(&state, &normalized, &usage).await {
+                return error_response(
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    "persistence_failed",
+                    message,
+                );
+            }
+
+            (status, Json(value)).into_response()
+        }
         ResponseBody::Stream(_) => {
             if let Some(lines) = state.provider.stream_response_lines(&normalized) {
+                let usage = provider_usage_from_sse_lines(&lines)
+                    .unwrap_or_else(|| estimated_usage_from_request(&normalized));
+                if let Err(message) = persist_request_and_usage(&state, &normalized, &usage).await {
+                    return error_response(
+                        StatusCode::INTERNAL_SERVER_ERROR,
+                        "persistence_failed",
+                        message,
+                    );
+                }
+
                 let mut response = (status, lines.concat()).into_response();
                 response.headers_mut().insert(
                     header::CONTENT_TYPE,
@@ -188,7 +215,7 @@ async fn get_models(State(state): State<Arc<ProxyState>>) -> Json<Value> {
 }
 
 fn validate_chat_request(payload: &ChatCompletionsRequest) -> Result<(), String> {
-    if payload.model.trim().is_empty() {
+    if extract_model(&payload.model).is_empty() {
         return Err("field `model` must not be empty".to_string());
     }
 
@@ -199,6 +226,119 @@ fn validate_chat_request(payload: &ChatCompletionsRequest) -> Result<(), String>
     if messages.is_empty() {
         return Err("field `messages` must contain at least one message".to_string());
     }
+
+    Ok(())
+}
+
+fn normalize_chat_request(
+    ctx: &RequestContext,
+    state: &ProxyState,
+    payload: &ChatCompletionsRequest,
+) -> NormalizedRequest {
+    let model = extract_model(&payload.model);
+    let estimate = estimate_tokens(&payload.messages);
+
+    NormalizedRequest {
+        id: ctx.request_id.clone(),
+        project_id: state.default_project_id.clone(),
+        session_id: state.default_session_id.clone(),
+        model_requested: model.clone(),
+        model_resolved: model,
+        provider_id: state.provider.provider_id().to_string(),
+        messages: payload.messages.clone(),
+        stream: payload.stream,
+        estimated_input_tokens: estimate.input_tokens,
+        estimated_output_tokens: estimate.output_tokens,
+        timestamp: Utc::now(),
+    }
+}
+
+fn extract_model(raw: &str) -> String {
+    raw.trim().to_string()
+}
+
+fn provider_usage_from_completion(payload: &Value) -> Option<NormalizedUsage> {
+    let usage = payload.get("usage")?;
+    let input_tokens = usage.get("prompt_tokens")?.as_u64()?;
+    let output_tokens = usage.get("completion_tokens")?.as_u64()?;
+    Some(NormalizedUsage {
+        input_tokens,
+        output_tokens,
+        source: UsageSource::Provider,
+        pricing_snapshot: usage.clone(),
+    })
+}
+
+fn provider_usage_from_sse_lines(lines: &[String]) -> Option<NormalizedUsage> {
+    for line in lines {
+        let Some(data) = line.strip_prefix("data:") else {
+            continue;
+        };
+
+        let data = data.trim();
+        if data.eq_ignore_ascii_case("[DONE]") {
+            continue;
+        }
+
+        let parsed: Value = serde_json::from_str(data).ok()?;
+        if let Some(usage) = provider_usage_from_completion(&parsed) {
+            return Some(usage);
+        }
+    }
+
+    None
+}
+
+fn estimated_usage_from_request(request: &NormalizedRequest) -> NormalizedUsage {
+    NormalizedUsage {
+        input_tokens: request.estimated_input_tokens,
+        output_tokens: request.estimated_output_tokens,
+        source: UsageSource::Estimated,
+        pricing_snapshot: json!({
+            "source": "token_estimation_hook",
+            "model": request.model_resolved
+        }),
+    }
+}
+
+async fn persist_request_and_usage(
+    state: &ProxyState,
+    normalized: &NormalizedRequest,
+    usage: &NormalizedUsage,
+) -> Result<(), String> {
+    let Some(store) = &state.store else {
+        return Ok(());
+    };
+
+    let project_id = ProjectRepo::upsert_by_path(store, &state.default_project_id)
+        .await
+        .map_err(|err| err.to_string())?;
+
+    let request = NewRequest {
+        id: normalized.id.clone(),
+        session_id: None,
+        project_id,
+        model_requested: normalized.model_requested.clone(),
+        model_used: normalized.model_resolved.clone(),
+        provider_id: normalized.provider_id.clone(),
+        started_at: normalized.timestamp,
+        is_streaming: normalized.stream,
+    };
+    RequestRepo::insert(store, &request)
+        .await
+        .map_err(|err| err.to_string())?;
+
+    let usage_record = UsageRecord {
+        request_id: normalized.id.clone(),
+        input_tokens: usage.input_tokens,
+        output_tokens: usage.output_tokens,
+        cost_usd: 0.0,
+        source: usage.source.clone(),
+        pricing_snapshot: usage.pricing_snapshot.clone(),
+    };
+    RequestRepo::insert_usage(store, &usage_record)
+        .await
+        .map_err(|err| err.to_string())?;
 
     Ok(())
 }
@@ -220,10 +360,19 @@ mod tests {
         body::{to_bytes, Body},
         http::Request,
     };
+    use sqlx::Row;
     use tower::ServiceExt;
 
     fn app() -> Router {
         build_router(ProxyState::mock_default())
+    }
+
+    async fn app_with_store() -> (Router, SqliteStore) {
+        let store = SqliteStore::connect("sqlite::memory:")
+            .await
+            .expect("create in-memory store");
+        let state = ProxyState::mock_default().with_store(store.clone());
+        (build_router(state), store)
     }
 
     #[tokio::test]
@@ -342,5 +491,82 @@ mod tests {
         let text = String::from_utf8(body.to_vec()).expect("utf8 body");
         assert!(text.contains("data: [DONE]"));
         assert!(text.contains("\"usage\""));
+    }
+
+    #[test]
+    fn normalization_extracts_model_stream_and_token_hook_fields() {
+        let state = ProxyState::mock_default();
+        let ctx = RequestContext {
+            request_id: "req_norm_01".to_string(),
+        };
+        let payload = ChatCompletionsRequest {
+            model: "  claude-sonnet-4-6 ".to_string(),
+            messages: json!([{ "role": "user", "content": "normalization test" }]),
+            stream: true,
+        };
+
+        let normalized = normalize_chat_request(&ctx, &state, &payload);
+        assert_eq!(normalized.id, "req_norm_01");
+        assert_eq!(normalized.model_requested, "claude-sonnet-4-6");
+        assert_eq!(normalized.model_resolved, "claude-sonnet-4-6");
+        assert!(normalized.stream);
+        assert!(normalized.estimated_input_tokens > 0);
+        assert!(normalized.estimated_output_tokens > 0);
+    }
+
+    #[tokio::test]
+    async fn request_and_usage_are_persisted_with_traceable_id_and_timestamp() {
+        let (app, store) = app_with_store().await;
+        let request = Request::builder()
+            .method("POST")
+            .uri("/v1/chat/completions")
+            .header(header::CONTENT_TYPE, "application/json")
+            .body(Body::from(
+                json!({
+                    "model": " claude-sonnet-4-6 ",
+                    "messages": [{"role":"user","content":"persist me"}],
+                    "stream": false
+                })
+                .to_string(),
+            ))
+            .expect("build request");
+
+        let response = app.oneshot(request).await.expect("response");
+        assert_eq!(response.status(), StatusCode::OK);
+        let request_id = response
+            .headers()
+            .get(REQUEST_ID_HEADER)
+            .and_then(|value| value.to_str().ok())
+            .expect("request id header")
+            .to_string();
+
+        let row = sqlx::query(
+            "SELECT id, model_requested, model_used, is_streaming, started_at FROM requests WHERE id = ?1",
+        )
+        .bind(&request_id)
+        .fetch_one(store.pool())
+        .await
+        .expect("request row");
+        assert_eq!(row.get::<String, _>("id"), request_id);
+        assert_eq!(row.get::<String, _>("model_requested"), "claude-sonnet-4-6");
+        assert_eq!(row.get::<String, _>("model_used"), "claude-sonnet-4-6");
+        assert_eq!(row.get::<i64, _>("is_streaming"), 0);
+
+        let started_at = row.get::<String, _>("started_at");
+        assert!(
+            chrono::DateTime::parse_from_rfc3339(&started_at).is_ok(),
+            "started_at should be RFC3339, got {started_at}"
+        );
+
+        let usage = sqlx::query(
+            "SELECT request_id, input_tokens, output_tokens FROM request_usage WHERE request_id = ?1",
+        )
+        .bind(&request_id)
+        .fetch_one(store.pool())
+        .await
+        .expect("usage row");
+        assert_eq!(usage.get::<String, _>("request_id"), request_id);
+        assert_eq!(usage.get::<i64, _>("input_tokens"), 120);
+        assert_eq!(usage.get::<i64, _>("output_tokens"), 48);
     }
 }


### PR DESCRIPTION
…e (#12)

- normalize inbound chat completion payloads (model, stream, request metadata)
- integrate token estimation hook from penny-cost
- persist request and usage records through penny-store
- add proxy tests for traceable request IDs/timestamps and persistence flow