### PR TITLE
feat(ledger): harden idempotency and transaction safety (#58)

### DIFF
--- a/crates/penny-ledger/src/lib.rs
+++ b/crates/penny-ledger/src/lib.rs
@@ -1,5 +1,7 @@
 //! Atomic cost ledger operations for PennyPrompt.
 
+use std::collections::HashMap;
+
 use penny_store::{SqliteStore, StoreError};
 use penny_types::{Budget, BudgetRemaining, Reservation};
 use sqlx::{query, query_scalar, Row};
@@ -18,6 +20,14 @@ pub enum LedgerError {
 #[derive(Debug, Clone)]
 pub struct CostLedger {
     store: SqliteStore,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct LedgerRow {
+    id: i64,
+    budget_id: i64,
+    amount_usd: f64,
+    running_total: f64,
 }
 
 impl CostLedger {
@@ -72,19 +82,26 @@ impl CostLedger {
             });
         }
 
-        let mut conn = self.store.pool().acquire().await?;
-        begin_immediate(&mut conn).await?;
+        let mut tx = begin_immediate(self.store.pool()).await?;
+
+        let existing_reserve_rows = request_entries_by_type(&mut tx, request_id, "reserve").await?;
+        if !existing_reserve_rows.is_empty() {
+            let reservation =
+                reservation_from_existing(budgets, estimated_cost, &existing_reserve_rows)?;
+            tx.commit().await?;
+            return Ok(reservation);
+        }
 
         let mut entries = Vec::with_capacity(budgets.len());
         let mut remaining_by_budget = Vec::with_capacity(budgets.len());
 
         for budget in budgets {
-            let current_total = latest_running_total(&mut conn, budget.id).await?;
+            let current_total = latest_running_total(&mut tx, budget.id).await?;
             let new_total = current_total + estimated_cost;
             if enforce_hard_limits {
                 if let Some(limit) = budget.hard_limit_usd {
                     if new_total > limit {
-                        rollback_quietly(&mut conn).await;
+                        tx.rollback().await?;
                         return Ok(Reservation::Denied {
                             budget: budget.clone(),
                             accumulated: new_total,
@@ -99,7 +116,7 @@ impl CostLedger {
             }
 
             let entry_id = insert_ledger_entry(
-                &mut conn,
+                &mut tx,
                 request_id,
                 "reserve",
                 budget.id,
@@ -117,7 +134,7 @@ impl CostLedger {
             });
         }
 
-        commit(&mut conn).await?;
+        tx.commit().await?;
         Ok(Reservation::Granted {
             entries,
             remaining_by_budget,
@@ -138,41 +155,44 @@ impl CostLedger {
             ));
         }
 
-        let mut conn = self.store.pool().acquire().await?;
-        begin_immediate(&mut conn).await?;
+        let mut tx = begin_immediate(self.store.pool()).await?;
 
-        let reserve_rows = query(
-            r#"
-            SELECT budget_id, amount_usd
-            FROM cost_ledger
-            WHERE request_id = ?1 AND entry_type = 'reserve'
-            ORDER BY id
-            "#,
-        )
-        .bind(request_id)
-        .fetch_all(&mut *conn)
-        .await?;
+        let existing_reconcile_ids =
+            request_entry_ids_by_type(&mut tx, request_id, "reconcile").await?;
+        if !existing_reconcile_ids.is_empty() {
+            tx.commit().await?;
+            return Ok(existing_reconcile_ids);
+        }
+
+        if has_request_entries_of_type(&mut tx, request_id, "release").await? {
+            tx.rollback().await?;
+            return Err(LedgerError::InvalidRequest(
+                "cannot reconcile request after release",
+            ));
+        }
+
+        let reserve_rows = request_entries_by_type(&mut tx, request_id, "reserve").await?;
+        if reserve_rows.is_empty() {
+            tx.rollback().await?;
+            return Err(LedgerError::InvalidRequest(
+                "cannot reconcile request without reserve entries",
+            ));
+        }
 
         let mut entry_ids = Vec::with_capacity(reserve_rows.len());
         for row in reserve_rows {
-            let budget_id: i64 = row.get("budget_id");
-            let reserved_amount: f64 = row.get("amount_usd");
+            let budget_id = row.budget_id;
+            let reserved_amount = row.amount_usd;
             let diff = actual_cost - reserved_amount;
-            let current_total = latest_running_total(&mut conn, budget_id).await?;
+            let current_total = latest_running_total(&mut tx, budget_id).await?;
             let new_total = current_total + diff;
-            let entry_id = insert_ledger_entry(
-                &mut conn,
-                request_id,
-                "reconcile",
-                budget_id,
-                diff,
-                new_total,
-            )
-            .await?;
+            let entry_id =
+                insert_ledger_entry(&mut tx, request_id, "reconcile", budget_id, diff, new_total)
+                    .await?;
             entry_ids.push(entry_id);
         }
 
-        commit(&mut conn).await?;
+        tx.commit().await?;
         Ok(entry_ids)
     }
 
@@ -181,30 +201,39 @@ impl CostLedger {
             return Err(LedgerError::InvalidRequest("request_id must not be empty"));
         }
 
-        let mut conn = self.store.pool().acquire().await?;
-        begin_immediate(&mut conn).await?;
+        let mut tx = begin_immediate(self.store.pool()).await?;
 
-        let reserve_rows = query(
-            r#"
-            SELECT budget_id, amount_usd
-            FROM cost_ledger
-            WHERE request_id = ?1 AND entry_type = 'reserve'
-            ORDER BY id
-            "#,
-        )
-        .bind(request_id)
-        .fetch_all(&mut *conn)
-        .await?;
+        let existing_release_ids =
+            request_entry_ids_by_type(&mut tx, request_id, "release").await?;
+        if !existing_release_ids.is_empty() {
+            tx.commit().await?;
+            return Ok(existing_release_ids);
+        }
+
+        if has_request_entries_of_type(&mut tx, request_id, "reconcile").await? {
+            tx.rollback().await?;
+            return Err(LedgerError::InvalidRequest(
+                "cannot release request after reconcile",
+            ));
+        }
+
+        let reserve_rows = request_entries_by_type(&mut tx, request_id, "reserve").await?;
+        if reserve_rows.is_empty() {
+            tx.rollback().await?;
+            return Err(LedgerError::InvalidRequest(
+                "cannot release request without reserve entries",
+            ));
+        }
 
         let mut entry_ids = Vec::with_capacity(reserve_rows.len());
         for row in reserve_rows {
-            let budget_id: i64 = row.get("budget_id");
-            let reserved_amount: f64 = row.get("amount_usd");
+            let budget_id = row.budget_id;
+            let reserved_amount = row.amount_usd;
             let release_amount = -reserved_amount;
-            let current_total = latest_running_total(&mut conn, budget_id).await?;
+            let current_total = latest_running_total(&mut tx, budget_id).await?;
             let new_total = current_total + release_amount;
             let entry_id = insert_ledger_entry(
-                &mut conn,
+                &mut tx,
                 request_id,
                 "release",
                 budget_id,
@@ -215,13 +244,62 @@ impl CostLedger {
             entry_ids.push(entry_id);
         }
 
-        commit(&mut conn).await?;
+        tx.commit().await?;
         Ok(entry_ids)
     }
 }
 
+fn reservation_from_existing(
+    budgets: &[Budget],
+    estimated_cost: f64,
+    rows: &[LedgerRow],
+) -> Result<Reservation, LedgerError> {
+    if rows.len() != budgets.len() {
+        return Err(LedgerError::InvalidRequest(
+            "existing reserve entries do not match requested budget set",
+        ));
+    }
+
+    let mut by_budget = HashMap::with_capacity(rows.len());
+    for row in rows {
+        if by_budget.insert(row.budget_id, row).is_some() {
+            return Err(LedgerError::InvalidRequest(
+                "duplicate reserve entries found for request and budget",
+            ));
+        }
+    }
+
+    let mut remaining_by_budget = Vec::with_capacity(budgets.len());
+    for budget in budgets {
+        let Some(row) = by_budget.get(&budget.id) else {
+            return Err(LedgerError::InvalidRequest(
+                "existing reserve entries do not match requested budget set",
+            ));
+        };
+
+        if (row.amount_usd - estimated_cost).abs() > 1e-9 {
+            return Err(LedgerError::InvalidRequest(
+                "estimated_cost does not match existing reservation",
+            ));
+        }
+
+        remaining_by_budget.push(BudgetRemaining {
+            budget_id: budget.id,
+            remaining_usd: budget
+                .hard_limit_usd
+                .map(|limit| limit - row.running_total)
+                .unwrap_or(f64::INFINITY),
+        });
+    }
+
+    Ok(Reservation::Granted {
+        entries: rows.iter().map(|row| row.id).collect(),
+        remaining_by_budget,
+    })
+}
+
 async fn latest_running_total(
-    conn: &mut sqlx::pool::PoolConnection<sqlx::Sqlite>,
+    tx: &mut sqlx::Transaction<'_, sqlx::Sqlite>,
     budget_id: i64,
 ) -> Result<f64, sqlx::Error> {
     query_scalar(
@@ -234,20 +312,20 @@ async fn latest_running_total(
         "#,
     )
     .bind(budget_id)
-    .fetch_optional(&mut **conn)
+    .fetch_optional(&mut **tx)
     .await
     .map(|value: Option<f64>| value.unwrap_or(0.0))
 }
 
 async fn insert_ledger_entry(
-    conn: &mut sqlx::pool::PoolConnection<sqlx::Sqlite>,
+    tx: &mut sqlx::Transaction<'_, sqlx::Sqlite>,
     request_id: &str,
     entry_type: &'static str,
     budget_id: i64,
     amount_usd: f64,
     running_total: f64,
 ) -> Result<i64, sqlx::Error> {
-    query(
+    let result = query(
         r#"
         INSERT INTO cost_ledger (
             request_id, entry_type, budget_id, amount_usd, running_total
@@ -260,28 +338,68 @@ async fn insert_ledger_entry(
     .bind(budget_id)
     .bind(amount_usd)
     .bind(running_total)
-    .execute(&mut **conn)
+    .execute(&mut **tx)
     .await?;
 
-    query_scalar("SELECT last_insert_rowid()")
-        .fetch_one(&mut **conn)
-        .await
+    Ok(result.last_insert_rowid())
 }
 
 async fn begin_immediate(
-    conn: &mut sqlx::pool::PoolConnection<sqlx::Sqlite>,
-) -> Result<(), sqlx::Error> {
-    query("BEGIN IMMEDIATE").execute(&mut **conn).await?;
-    Ok(())
+    pool: &sqlx::SqlitePool,
+) -> Result<sqlx::Transaction<'_, sqlx::Sqlite>, sqlx::Error> {
+    pool.begin_with("BEGIN IMMEDIATE").await
 }
 
-async fn commit(conn: &mut sqlx::pool::PoolConnection<sqlx::Sqlite>) -> Result<(), sqlx::Error> {
-    query("COMMIT").execute(&mut **conn).await?;
-    Ok(())
+async fn request_entries_by_type(
+    tx: &mut sqlx::Transaction<'_, sqlx::Sqlite>,
+    request_id: &str,
+    entry_type: &'static str,
+) -> Result<Vec<LedgerRow>, sqlx::Error> {
+    let rows = query(
+        r#"
+        SELECT id, budget_id, amount_usd, running_total
+        FROM cost_ledger
+        WHERE request_id = ?1 AND entry_type = ?2
+        ORDER BY id
+        "#,
+    )
+    .bind(request_id)
+    .bind(entry_type)
+    .fetch_all(&mut **tx)
+    .await?;
+
+    let mut entries = Vec::with_capacity(rows.len());
+    for row in rows {
+        entries.push(LedgerRow {
+            id: row.get("id"),
+            budget_id: row.get("budget_id"),
+            amount_usd: row.get("amount_usd"),
+            running_total: row.get("running_total"),
+        });
+    }
+    Ok(entries)
 }
 
-async fn rollback_quietly(conn: &mut sqlx::pool::PoolConnection<sqlx::Sqlite>) {
-    let _ = query("ROLLBACK").execute(&mut **conn).await;
+async fn request_entry_ids_by_type(
+    tx: &mut sqlx::Transaction<'_, sqlx::Sqlite>,
+    request_id: &str,
+    entry_type: &'static str,
+) -> Result<Vec<i64>, sqlx::Error> {
+    Ok(request_entries_by_type(tx, request_id, entry_type)
+        .await?
+        .into_iter()
+        .map(|row| row.id)
+        .collect())
+}
+
+async fn has_request_entries_of_type(
+    tx: &mut sqlx::Transaction<'_, sqlx::Sqlite>,
+    request_id: &str,
+    entry_type: &'static str,
+) -> Result<bool, sqlx::Error> {
+    Ok(!request_entry_ids_by_type(tx, request_id, entry_type)
+        .await?
+        .is_empty())
 }
 
 #[cfg(test)]
@@ -486,5 +604,174 @@ mod tests {
         let running_total: f64 = row.get("running_total");
         assert!((amount + 2.0).abs() < 1e-9);
         assert!(running_total.abs() < 1e-9);
+    }
+
+    #[tokio::test]
+    async fn reserve_is_idempotent_for_same_request_id() {
+        let store = setup_store().await;
+        let budget = insert_budget(&store, Some(10.0)).await;
+        let ledger = CostLedger::new(store.clone());
+
+        let first = ledger
+            .reserve("req_idempotent_reserve", std::slice::from_ref(&budget), 2.0)
+            .await
+            .expect("first reserve");
+        let second = ledger
+            .reserve("req_idempotent_reserve", std::slice::from_ref(&budget), 2.0)
+            .await
+            .expect("second reserve should be idempotent");
+
+        match (first, second) {
+            (
+                Reservation::Granted {
+                    entries: first_entries,
+                    ..
+                },
+                Reservation::Granted {
+                    entries: second_entries,
+                    ..
+                },
+            ) => {
+                assert_eq!(first_entries, second_entries);
+                assert_eq!(first_entries.len(), 1);
+            }
+            other => panic!("unexpected reserve results: {other:?}"),
+        }
+
+        let rows: i64 = query_scalar(
+            "SELECT COUNT(*) FROM cost_ledger WHERE request_id = 'req_idempotent_reserve' AND entry_type = 'reserve'",
+        )
+        .fetch_one(store.pool())
+        .await
+        .expect("count reserve rows");
+        assert_eq!(rows, 1);
+    }
+
+    #[tokio::test]
+    async fn reconcile_is_idempotent_for_same_request_id() {
+        let store = setup_store().await;
+        let budget = insert_budget(&store, Some(20.0)).await;
+        let ledger = CostLedger::new(store.clone());
+
+        ledger
+            .reserve(
+                "req_idempotent_reconcile",
+                std::slice::from_ref(&budget),
+                2.0,
+            )
+            .await
+            .expect("reserve");
+
+        let first = ledger
+            .reconcile("req_idempotent_reconcile", 3.0)
+            .await
+            .expect("first reconcile");
+        let second = ledger
+            .reconcile("req_idempotent_reconcile", 3.0)
+            .await
+            .expect("second reconcile should be idempotent");
+
+        assert_eq!(first, second);
+        assert_eq!(first.len(), 1);
+
+        let rows: i64 = query_scalar(
+            "SELECT COUNT(*) FROM cost_ledger WHERE request_id = 'req_idempotent_reconcile' AND entry_type = 'reconcile'",
+        )
+        .fetch_one(store.pool())
+        .await
+        .expect("count reconcile rows");
+        assert_eq!(rows, 1);
+    }
+
+    #[tokio::test]
+    async fn release_is_idempotent_for_same_request_id() {
+        let store = setup_store().await;
+        let budget = insert_budget(&store, Some(20.0)).await;
+        let ledger = CostLedger::new(store.clone());
+
+        ledger
+            .reserve("req_idempotent_release", std::slice::from_ref(&budget), 2.0)
+            .await
+            .expect("reserve");
+
+        let first = ledger
+            .release("req_idempotent_release")
+            .await
+            .expect("first release");
+        let second = ledger
+            .release("req_idempotent_release")
+            .await
+            .expect("second release should be idempotent");
+
+        assert_eq!(first, second);
+        assert_eq!(first.len(), 1);
+
+        let rows: i64 = query_scalar(
+            "SELECT COUNT(*) FROM cost_ledger WHERE request_id = 'req_idempotent_release' AND entry_type = 'release'",
+        )
+        .fetch_one(store.pool())
+        .await
+        .expect("count release rows");
+        assert_eq!(rows, 1);
+    }
+
+    #[tokio::test]
+    async fn reconcile_after_release_is_rejected() {
+        let store = setup_store().await;
+        let budget = insert_budget(&store, Some(20.0)).await;
+        let ledger = CostLedger::new(store);
+
+        ledger
+            .reserve(
+                "req_conflict_reconcile_after_release",
+                std::slice::from_ref(&budget),
+                2.0,
+            )
+            .await
+            .expect("reserve");
+        ledger
+            .release("req_conflict_reconcile_after_release")
+            .await
+            .expect("release");
+
+        let err = ledger
+            .reconcile("req_conflict_reconcile_after_release", 3.0)
+            .await
+            .expect_err("reconcile after release should fail");
+
+        assert!(matches!(
+            err,
+            LedgerError::InvalidRequest("cannot reconcile request after release")
+        ));
+    }
+
+    #[tokio::test]
+    async fn release_after_reconcile_is_rejected() {
+        let store = setup_store().await;
+        let budget = insert_budget(&store, Some(20.0)).await;
+        let ledger = CostLedger::new(store);
+
+        ledger
+            .reserve(
+                "req_conflict_release_after_reconcile",
+                std::slice::from_ref(&budget),
+                2.0,
+            )
+            .await
+            .expect("reserve");
+        ledger
+            .reconcile("req_conflict_release_after_reconcile", 3.0)
+            .await
+            .expect("reconcile");
+
+        let err = ledger
+            .release("req_conflict_release_after_reconcile")
+            .await
+            .expect_err("release after reconcile should fail");
+
+        assert!(matches!(
+            err,
+            LedgerError::InvalidRequest("cannot release request after reconcile")
+        ));
     }
 }


### PR DESCRIPTION
## Summary
Implements **#58** (under **#15 M3 Atomic Budgets**) to harden ledger correctness before budget enforcement integration in #18.

## Why this now
`#18` depends on deterministic ledger behavior. Without idempotency and strong transaction boundaries, retries/duplicates can corrupt running totals and budget decisions.

## What changed
- Added idempotency guards for `reserve`, `reconcile`, and `release` by `request_id`.
- Defined deterministic retry behavior (repeated calls return existing operation results, no duplicate ledger rows).
- Enforced terminal operation exclusivity:
  - reject `reconcile` after `release`
  - reject `release` after `reconcile`
- Migrated operation flow to robust `sqlx` transaction handling with `BEGIN IMMEDIATE`.
- Removed extra `SELECT last_insert_rowid()` round-trip by using execution metadata.

## Tests
Added/updated unit tests in `penny-ledger` for:
- reserve/reconcile/release idempotency
- conflicting operation sequences
- existing reserve/reconcile/release correctness paths

Executed locally:
- `cargo fmt --all`
- `cargo test -p penny-ledger`
- `cargo test -p penny-budget`
- `cargo check --workspace`

## Scope
This PR is focused on ledger correctness hardening only (no schema migration, no proxy enforcement changes).

Closes #58
