### PR TITLE
perf(budget,store): collapse budget lookup fanout and remove soft-limit N+1 (#57)

### DIFF
--- a/crates/penny-budget/src/lib.rs
+++ b/crates/penny-budget/src/lib.rs
@@ -10,7 +10,7 @@ use penny_types::{
     ScopeType, Severity, WindowType,
 };
 use serde_json::json;
-use sqlx::query_scalar;
+use sqlx::{QueryBuilder, Row, Sqlite};
 
 #[derive(Clone)]
 pub struct BudgetEvaluator {
@@ -204,40 +204,13 @@ impl BudgetEvaluator {
         &self,
         request: &NormalizedRequest,
     ) -> Result<Vec<Budget>, String> {
-        let scopes = [
-            (ScopeType::Global, "*".to_string()),
-            (ScopeType::Project, request.project_id.clone()),
-            (ScopeType::Session, request.session_id.clone()),
-        ];
-        let windows = [
-            WindowType::Day,
-            WindowType::Week,
-            WindowType::Month,
-            WindowType::Total,
-        ];
-
-        let mut dedupe = HashSet::new();
-        let mut budgets = Vec::new();
-
-        for window in &windows {
-            for (scope_type, scope_id) in &scopes {
-                let found = BudgetRepo::list_applicable(
-                    &self.store,
-                    scope_type.clone(),
-                    scope_id,
-                    window.clone(),
-                )
-                .await
-                .map_err(|error| error.to_string())?;
-
-                for budget in found {
-                    if dedupe.insert(budget.id) {
-                        budgets.push(budget);
-                    }
-                }
-            }
-        }
-
+        let mut budgets = BudgetRepo::list_applicable_for_request(
+            &self.store,
+            &request.project_id,
+            &request.session_id,
+        )
+        .await
+        .map_err(|error| error.to_string())?;
         budgets.sort_by_key(|budget| budget.id);
         Ok(budgets)
     }
@@ -287,6 +260,26 @@ impl BudgetEvaluator {
             remaining_map.insert(item.budget_id, item.remaining_usd);
         }
 
+        let mut lookup_budget_ids = HashSet::new();
+        for budget in budgets {
+            if budget.hard_limit_usd.is_none() {
+                lookup_budget_ids.insert(budget.id);
+                continue;
+            }
+
+            if !matches!(
+                remaining_map.get(&budget.id),
+                Some(remaining) if remaining.is_finite()
+            ) {
+                lookup_budget_ids.insert(budget.id);
+            }
+        }
+
+        let running_totals = self
+            .latest_running_totals(&lookup_budget_ids.into_iter().collect::<Vec<_>>())
+            .await
+            .map_err(|error| error.to_string())?;
+
         let mut warnings = Vec::new();
         for budget in budgets {
             let Some(soft_limit) = budget.soft_limit_usd else {
@@ -296,15 +289,10 @@ impl BudgetEvaluator {
             let accumulated = if let Some(limit) = budget.hard_limit_usd {
                 match remaining_map.get(&budget.id) {
                     Some(remaining) if remaining.is_finite() => limit - *remaining,
-                    _ => self
-                        .latest_running_total(budget.id)
-                        .await
-                        .map_err(|error| error.to_string())?,
+                    _ => *running_totals.get(&budget.id).unwrap_or(&0.0),
                 }
             } else {
-                self.latest_running_total(budget.id)
-                    .await
-                    .map_err(|error| error.to_string())?
+                *running_totals.get(&budget.id).unwrap_or(&0.0)
             };
 
             if accumulated >= soft_limit {
@@ -321,20 +309,41 @@ impl BudgetEvaluator {
         Ok(warnings)
     }
 
-    async fn latest_running_total(&self, budget_id: i64) -> Result<f64, sqlx::Error> {
-        query_scalar(
+    async fn latest_running_totals(
+        &self,
+        budget_ids: &[i64],
+    ) -> Result<HashMap<i64, f64>, sqlx::Error> {
+        if budget_ids.is_empty() {
+            return Ok(HashMap::new());
+        }
+
+        let mut qb = QueryBuilder::<Sqlite>::new(
             r#"
-            SELECT running_total
+            SELECT budget_id, running_total
             FROM cost_ledger
-            WHERE budget_id = ?1
-            ORDER BY id DESC
-            LIMIT 1
+            WHERE budget_id IN (
             "#,
-        )
-        .bind(budget_id)
-        .fetch_optional(self.store.pool())
-        .await
-        .map(|value: Option<f64>| value.unwrap_or(0.0))
+        );
+        {
+            let mut separated = qb.separated(", ");
+            for budget_id in budget_ids {
+                separated.push_bind(*budget_id);
+            }
+        }
+        qb.push(
+            r#")
+            ORDER BY budget_id ASC, id DESC
+            "#,
+        );
+
+        let rows = qb.build().fetch_all(self.store.pool()).await?;
+        let mut totals = HashMap::with_capacity(budget_ids.len());
+        for row in rows {
+            let budget_id: i64 = row.get("budget_id");
+            let running_total: f64 = row.get("running_total");
+            totals.entry(budget_id).or_insert(running_total);
+        }
+        Ok(totals)
     }
 
     async fn failsafe_decision(

--- a/crates/penny-store/src/lib.rs
+++ b/crates/penny-store/src/lib.rs
@@ -220,6 +220,11 @@ pub trait BudgetRepo {
         scope_id: &str,
         window_type: WindowType,
     ) -> Result<Vec<Budget>, StoreError>;
+    async fn list_applicable_for_request(
+        &self,
+        project_id: &str,
+        session_id: &str,
+    ) -> Result<Vec<Budget>, StoreError>;
     async fn upsert(&self, budget: &Budget) -> Result<Budget, StoreError>;
     async fn list_all(&self) -> Result<Vec<Budget>, StoreError>;
 }
@@ -457,6 +462,32 @@ impl BudgetRepo for SqliteStore {
         .bind(window_type_db)
         .bind(scope_type_db)
         .bind(scope_id)
+        .fetch_all(&self.pool)
+        .await?;
+
+        rows.into_iter().map(budget_from_row).collect()
+    }
+
+    async fn list_applicable_for_request(
+        &self,
+        project_id: &str,
+        session_id: &str,
+    ) -> Result<Vec<Budget>, StoreError> {
+        let rows = sqlx::query(
+            r#"
+            SELECT id, scope_type, scope_id, window_type, hard_limit_usd, soft_limit_usd, action_on_hard, action_on_soft
+            FROM budgets
+            WHERE window_type IN ('day', 'week', 'month', 'total')
+              AND (
+                (scope_type = 'global' AND scope_id = '*')
+                OR (scope_type = 'project' AND scope_id = ?1)
+                OR (scope_type = 'session' AND scope_id = ?2)
+              )
+            ORDER BY id
+            "#,
+        )
+        .bind(project_id)
+        .bind(session_id)
         .fetch_all(&self.pool)
         .await?;
 
@@ -1044,6 +1075,66 @@ mod tests {
 
         let all = store.list_all().await.expect("list all");
         assert_eq!(all.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn budget_repo_list_applicable_for_request_returns_all_scope_matches() {
+        let store = setup_store().await;
+
+        let budgets = vec![
+            Budget {
+                id: 0,
+                scope_type: ScopeType::Global,
+                scope_id: "*".into(),
+                window_type: WindowType::Day,
+                hard_limit_usd: Some(100.0),
+                soft_limit_usd: None,
+                action_on_hard: "block".into(),
+                action_on_soft: "warn".into(),
+            },
+            Budget {
+                id: 0,
+                scope_type: ScopeType::Project,
+                scope_id: "project-alpha".into(),
+                window_type: WindowType::Week,
+                hard_limit_usd: Some(200.0),
+                soft_limit_usd: None,
+                action_on_hard: "block".into(),
+                action_on_soft: "warn".into(),
+            },
+            Budget {
+                id: 0,
+                scope_type: ScopeType::Session,
+                scope_id: "session-123".into(),
+                window_type: WindowType::Month,
+                hard_limit_usd: Some(300.0),
+                soft_limit_usd: None,
+                action_on_hard: "block".into(),
+                action_on_soft: "warn".into(),
+            },
+            Budget {
+                id: 0,
+                scope_type: ScopeType::Project,
+                scope_id: "other-project".into(),
+                window_type: WindowType::Total,
+                hard_limit_usd: Some(400.0),
+                soft_limit_usd: None,
+                action_on_hard: "block".into(),
+                action_on_soft: "warn".into(),
+            },
+        ];
+
+        for budget in &budgets {
+            store.upsert(budget).await.expect("upsert budget");
+        }
+
+        let found = store
+            .list_applicable_for_request("project-alpha", "session-123")
+            .await
+            .expect("list applicable for request");
+
+        let found_ids: Vec<i64> = found.into_iter().map(|budget| budget.id).collect();
+        assert_eq!(found_ids.len(), 3);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
Implements **#57** under **#15 (M3 Atomic Budgets)** by reducing budget-evaluator database round trips and removing soft-limit N+1 lookups.

## Why
Current evaluator flow can over-query under traffic:
- Budget applicability can fan out to multiple queries per request.
- Soft-limit checks can trigger per-budget running-total reads (N+1).

This PR keeps behavior parity while optimizing query path before wider M3/M4 load.

## What Changed
- Added repository method to fetch all request-applicable budgets in a single query:
  - `BudgetRepo::list_applicable_for_request(project_id, session_id)`
  - Covers global/project/session scopes and all window types.
- Updated `BudgetEvaluator::lookup_applicable_budgets` to use the new single-query method.
- Reworked soft-limit evaluation to avoid per-budget DB lookups:
  - Added batched `latest_running_totals(&[budget_id])`
  - Reuses in-memory remaining values when available
  - Falls back to a single aggregated ledger read for needed budget IDs.

## Behavior / Compatibility
- No intended behavior change to guard/observe routing semantics.
- Event contracts remain the same (`budget_check`, `budget_warn`, `budget_block`, `mode_failsafe`).
- Scope/window applicability semantics are preserved.

## Tests
- Added `budget_repo_list_applicable_for_request_returns_all_scope_matches` in `penny-store`.
- Existing `penny-budget` tests continue passing (including observe/guard and window coverage).

## Validation
- `cargo fmt --all`
- `cargo test -p penny-store`
- `cargo test -p penny-budget`
- `cargo check --workspace`

Closes #57
