### PR TITLE
feat(config,budget): seed budgets from config with preset source tagging (#19)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1135,6 +1135,7 @@ dependencies = [
  "axum",
  "chrono",
  "penny-budget",
+ "penny-config",
  "penny-cost",
  "penny-ledger",
  "penny-providers",

--- a/crates/penny-budget/src/lib.rs
+++ b/crates/penny-budget/src/lib.rs
@@ -492,6 +492,7 @@ mod tests {
                 soft_limit_usd: soft_limit,
                 action_on_hard: "block".to_string(),
                 action_on_soft: "warn".to_string(),
+                preset_source: None,
             },
         )
         .await

--- a/crates/penny-config/src/lib.rs
+++ b/crates/penny-config/src/lib.rs
@@ -87,6 +87,8 @@ pub struct BudgetConfig {
     pub action_on_hard: String,
     #[serde(default = "default_action_on_soft")]
     pub action_on_soft: String,
+    #[serde(default)]
+    pub preset_source: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -161,7 +163,8 @@ pub fn load_config(opts: LoadOptions) -> Result<AppConfig, ConfigError> {
                 path: preset_path.display().to_string(),
             });
         }
-        let preset_partial = read_partial(&preset_path)?;
+        let mut preset_partial = read_partial(&preset_path)?;
+        tag_preset_budget_source(&mut preset_partial, preset);
         merged.merge_from(preset_partial);
     }
 
@@ -184,6 +187,18 @@ fn default_action_on_hard() -> String {
 
 fn default_action_on_soft() -> String {
     "warn".to_string()
+}
+
+fn tag_preset_budget_source(cfg: &mut PartialAppConfig, preset: &str) {
+    let Some(budgets) = cfg.budgets.as_mut() else {
+        return;
+    };
+    let source = format!("preset:{preset}");
+    for budget in budgets {
+        if budget.preset_source.is_none() {
+            budget.preset_source = Some(source.clone());
+        }
+    }
 }
 
 fn resolve_repo_root(repository_root: Option<PathBuf>) -> Result<PathBuf, ConfigError> {

--- a/crates/penny-ledger/src/lib.rs
+++ b/crates/penny-ledger/src/lib.rs
@@ -427,6 +427,7 @@ mod tests {
                 soft_limit_usd: None,
                 action_on_hard: "block".to_string(),
                 action_on_soft: "warn".to_string(),
+                preset_source: None,
             },
         )
         .await

--- a/crates/penny-proxy/Cargo.toml
+++ b/crates/penny-proxy/Cargo.toml
@@ -9,6 +9,7 @@ axum = "0.8"
 chrono = { version = "0.4", features = ["serde"] }
 penny-cost = { path = "../penny-cost" }
 penny-budget = { path = "../penny-budget" }
+penny-config = { path = "../penny-config" }
 penny-ledger = { path = "../penny-ledger" }
 penny-providers = { path = "../penny-providers" }
 penny-store = { path = "../penny-store" }

--- a/crates/penny-proxy/src/lib.rs
+++ b/crates/penny-proxy/src/lib.rs
@@ -17,12 +17,19 @@ use axum::{
 };
 use chrono::Utc;
 use penny_budget::BudgetEvaluator;
+use penny_config::{
+    AppConfig as RuntimeConfig, BudgetConfig as RuntimeBudgetConfig, ScopeType as ConfigScopeType,
+    WindowType as ConfigWindowType,
+};
 use penny_cost::{estimate_tokens, PricingEngine};
 use penny_ledger::CostLedger;
 use penny_providers::{MockProvider, MockProviderConfig, ProviderAdapter, ProviderError};
-use penny_store::{NewRequest, ProjectRepo, RequestRepo, SessionRepo, SqliteStore, UsageRecord};
+use penny_store::{
+    BudgetRepo, NewRequest, ProjectRepo, RequestRepo, SessionRepo, SqliteStore, UsageRecord,
+};
 use penny_types::{
-    BudgetBlockDetail, Mode, NormalizedRequest, ResponseBody, RouteDecision, UsageSource,
+    Budget, BudgetBlockDetail, Mode, NormalizedRequest, ResponseBody, RouteDecision, ScopeType,
+    UsageSource, WindowType,
 };
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
@@ -91,6 +98,19 @@ impl ProxyState {
         let models = mock.config().supported_models.clone();
         Self::with_provider(Arc::new(mock), models)
     }
+}
+
+pub async fn build_state_from_config(
+    provider: Arc<dyn ProviderAdapter>,
+    models: Vec<String>,
+    store: SqliteStore,
+    config: &RuntimeConfig,
+) -> Result<ProxyState, String> {
+    seed_budgets_from_runtime_config(&store, config).await?;
+    Ok(ProxyState::with_provider(provider, models)
+        .with_store(store)
+        .with_mode(mode_from_config(&config.server.mode))
+        .with_session_window_minutes(config.attribution.session_window_minutes as u64))
 }
 
 #[derive(Debug, Clone)]
@@ -533,6 +553,59 @@ async fn ensure_session_override_exists(
     Ok(())
 }
 
+pub async fn seed_budgets_from_runtime_config(
+    store: &SqliteStore,
+    config: &RuntimeConfig,
+) -> Result<Vec<Budget>, String> {
+    let mut seeded = Vec::with_capacity(config.budgets.len());
+    for budget in &config.budgets {
+        let mapped = map_config_budget(budget);
+        let stored = BudgetRepo::upsert(store, &mapped)
+            .await
+            .map_err(|err| err.to_string())?;
+        seeded.push(stored);
+    }
+    Ok(seeded)
+}
+
+fn map_config_budget(budget: &RuntimeBudgetConfig) -> Budget {
+    Budget {
+        id: 0,
+        scope_type: scope_type_from_config(&budget.scope_type),
+        scope_id: budget.scope_id.clone(),
+        window_type: window_type_from_config(&budget.window_type),
+        hard_limit_usd: budget.hard_limit_usd,
+        soft_limit_usd: budget.soft_limit_usd,
+        action_on_hard: budget.action_on_hard.clone(),
+        action_on_soft: budget.action_on_soft.clone(),
+        preset_source: budget.preset_source.clone(),
+    }
+}
+
+fn scope_type_from_config(scope: &ConfigScopeType) -> ScopeType {
+    match scope {
+        ConfigScopeType::Global => ScopeType::Global,
+        ConfigScopeType::Project => ScopeType::Project,
+        ConfigScopeType::Session => ScopeType::Session,
+    }
+}
+
+fn window_type_from_config(window: &ConfigWindowType) -> WindowType {
+    match window {
+        ConfigWindowType::Day => WindowType::Day,
+        ConfigWindowType::Week => WindowType::Week,
+        ConfigWindowType::Month => WindowType::Month,
+        ConfigWindowType::Total => WindowType::Total,
+    }
+}
+
+fn mode_from_config(mode: &penny_config::Mode) -> Mode {
+    match mode {
+        penny_config::Mode::Observe => Mode::Observe,
+        penny_config::Mode::Guard => Mode::Guard,
+    }
+}
+
 async fn evaluate_budget_before_dispatch(
     state: &ProxyState,
     request: &NormalizedRequest,
@@ -839,10 +912,13 @@ mod tests {
         body::{to_bytes, Body},
         http::Request,
     };
+    use penny_budget::BudgetEvaluator;
+    use penny_config::{load_config, LoadOptions};
     use penny_cost::import_pricebook_files;
     use penny_store::BudgetRepo;
-    use penny_types::{Budget, ScopeType, WindowType};
+    use penny_types::{Budget, RouteDecision, ScopeType, WindowType};
     use sqlx::Row;
+    use std::fs;
     use std::path::PathBuf;
     use tempfile::TempDir;
     use tower::ServiceExt;
@@ -887,10 +963,128 @@ mod tests {
                 soft_limit_usd: None,
                 action_on_hard: "block".to_string(),
                 action_on_soft: "warn".to_string(),
+                preset_source: None,
             },
         )
         .await
         .expect("seed budget");
+    }
+
+    fn repo_root() -> PathBuf {
+        PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("../..")
+            .canonicalize()
+            .expect("resolve repo root")
+    }
+
+    fn budget_request(id: &str) -> NormalizedRequest {
+        NormalizedRequest {
+            id: id.to_string(),
+            project_id: "project-alpha".to_string(),
+            session_id: "session-1".to_string(),
+            model_requested: "claude-sonnet-4-6".to_string(),
+            model_resolved: "claude-sonnet-4-6".to_string(),
+            provider_id: "mock".to_string(),
+            messages: json!([{ "role": "user", "content": "hello" }]),
+            stream: false,
+            estimated_input_tokens: 100,
+            estimated_output_tokens: 50,
+            timestamp: Utc::now(),
+        }
+    }
+
+    #[tokio::test]
+    async fn budget_seeding_from_preset_is_idempotent_and_tagged() {
+        let store = SqliteStore::connect("sqlite::memory:")
+            .await
+            .expect("create in-memory store");
+        let config = load_config(LoadOptions {
+            repository_root: Some(repo_root()),
+            preset: Some("team".to_string()),
+            ..LoadOptions::default()
+        })
+        .expect("load config with team preset");
+
+        let first = seed_budgets_from_runtime_config(&store, &config)
+            .await
+            .expect("first seed");
+        let second = seed_budgets_from_runtime_config(&store, &config)
+            .await
+            .expect("second seed");
+        assert_eq!(first.len(), config.budgets.len());
+        assert_eq!(second.len(), config.budgets.len());
+
+        let all = BudgetRepo::list_all(&store)
+            .await
+            .expect("list all budgets");
+        assert_eq!(all.len(), config.budgets.len());
+        assert!(all
+            .iter()
+            .all(|budget| budget.preset_source.as_deref() == Some("preset:team")));
+    }
+
+    #[tokio::test]
+    async fn user_budget_override_replaces_preset_values_safely() {
+        let store = SqliteStore::connect("sqlite::memory:")
+            .await
+            .expect("create in-memory store");
+        let temp = TempDir::new().expect("temp dir");
+        let user_config_path = temp.path().join("config.toml");
+        fs::write(
+            &user_config_path,
+            r#"
+[[budgets]]
+scope_type = "global"
+scope_id = "*"
+window_type = "day"
+hard_limit_usd = 7.0
+action_on_hard = "block"
+action_on_soft = "warn"
+"#,
+        )
+        .expect("write user config");
+
+        let config = load_config(LoadOptions {
+            repository_root: Some(repo_root()),
+            config_path: Some(user_config_path),
+            preset: Some("team".to_string()),
+        })
+        .expect("load config with user override");
+
+        seed_budgets_from_runtime_config(&store, &config)
+            .await
+            .expect("seed budgets");
+
+        let all = BudgetRepo::list_all(&store)
+            .await
+            .expect("list all budgets");
+        assert_eq!(all.len(), 1);
+        assert_eq!(all[0].window_type, WindowType::Day);
+        assert_eq!(all[0].hard_limit_usd, Some(7.0));
+        assert_eq!(all[0].preset_source, None);
+    }
+
+    #[tokio::test]
+    async fn seeded_budgets_are_immediately_visible_to_evaluator() {
+        let store = SqliteStore::connect("sqlite::memory:")
+            .await
+            .expect("create in-memory store");
+        let config = load_config(LoadOptions {
+            repository_root: Some(repo_root()),
+            preset: Some("indie".to_string()),
+            ..LoadOptions::default()
+        })
+        .expect("load config with indie preset");
+
+        seed_budgets_from_runtime_config(&store, &config)
+            .await
+            .expect("seed budgets");
+
+        let evaluator = BudgetEvaluator::new(store, Mode::Guard);
+        let decision = evaluator
+            .evaluate(&budget_request("req_seeded_eval"), 11.0)
+            .await;
+        assert!(matches!(decision, RouteDecision::Block { .. }));
     }
 
     #[tokio::test]

--- a/crates/penny-store/src/lib.rs
+++ b/crates/penny-store/src/lib.rs
@@ -449,7 +449,7 @@ impl BudgetRepo for SqliteStore {
         let window_type_db = window_type_to_db(&window_type);
         let rows = sqlx::query(
             r#"
-            SELECT id, scope_type, scope_id, window_type, hard_limit_usd, soft_limit_usd, action_on_hard, action_on_soft
+            SELECT id, scope_type, scope_id, window_type, hard_limit_usd, soft_limit_usd, action_on_hard, action_on_soft, preset_source
             FROM budgets
             WHERE window_type = ?1
               AND (
@@ -475,7 +475,7 @@ impl BudgetRepo for SqliteStore {
     ) -> Result<Vec<Budget>, StoreError> {
         let rows = sqlx::query(
             r#"
-            SELECT id, scope_type, scope_id, window_type, hard_limit_usd, soft_limit_usd, action_on_hard, action_on_soft
+            SELECT id, scope_type, scope_id, window_type, hard_limit_usd, soft_limit_usd, action_on_hard, action_on_soft, preset_source
             FROM budgets
             WHERE window_type IN ('day', 'week', 'month', 'total')
               AND (
@@ -508,8 +508,9 @@ impl BudgetRepo for SqliteStore {
                     hard_limit_usd = ?4,
                     soft_limit_usd = ?5,
                     action_on_hard = ?6,
-                    action_on_soft = ?7
-                WHERE id = ?8
+                    action_on_soft = ?7,
+                    preset_source = ?8
+                WHERE id = ?9
                 "#,
             )
             .bind(scope_type_db)
@@ -519,6 +520,7 @@ impl BudgetRepo for SqliteStore {
             .bind(budget.soft_limit_usd)
             .bind(&budget.action_on_hard)
             .bind(&budget.action_on_soft)
+            .bind(&budget.preset_source)
             .bind(budget.id)
             .execute(&self.pool)
             .await?;
@@ -549,14 +551,16 @@ impl BudgetRepo for SqliteStore {
                 SET hard_limit_usd = ?1,
                     soft_limit_usd = ?2,
                     action_on_hard = ?3,
-                    action_on_soft = ?4
-                WHERE id = ?5
+                    action_on_soft = ?4,
+                    preset_source = ?5
+                WHERE id = ?6
                 "#,
             )
             .bind(budget.hard_limit_usd)
             .bind(budget.soft_limit_usd)
             .bind(&budget.action_on_hard)
             .bind(&budget.action_on_soft)
+            .bind(&budget.preset_source)
             .bind(id)
             .execute(&self.pool)
             .await?;
@@ -565,9 +569,9 @@ impl BudgetRepo for SqliteStore {
             sqlx::query(
                 r#"
                 INSERT INTO budgets (
-                    scope_type, scope_id, window_type, hard_limit_usd, soft_limit_usd, action_on_hard, action_on_soft
+                    scope_type, scope_id, window_type, hard_limit_usd, soft_limit_usd, action_on_hard, action_on_soft, preset_source
                 )
-                VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)
+                VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)
                 "#,
             )
             .bind(scope_type_db)
@@ -577,6 +581,7 @@ impl BudgetRepo for SqliteStore {
             .bind(budget.soft_limit_usd)
             .bind(&budget.action_on_hard)
             .bind(&budget.action_on_soft)
+            .bind(&budget.preset_source)
             .execute(&self.pool)
             .await?;
             sqlx::query_scalar("SELECT last_insert_rowid()")
@@ -592,7 +597,7 @@ impl BudgetRepo for SqliteStore {
     async fn list_all(&self) -> Result<Vec<Budget>, StoreError> {
         let rows = sqlx::query(
             r#"
-            SELECT id, scope_type, scope_id, window_type, hard_limit_usd, soft_limit_usd, action_on_hard, action_on_soft
+            SELECT id, scope_type, scope_id, window_type, hard_limit_usd, soft_limit_usd, action_on_hard, action_on_soft, preset_source
             FROM budgets
             ORDER BY id
             "#,
@@ -883,6 +888,7 @@ fn budget_from_row(row: sqlx::sqlite::SqliteRow) -> Result<Budget, StoreError> {
         soft_limit_usd: row.get("soft_limit_usd"),
         action_on_hard: row.get("action_on_hard"),
         action_on_soft: row.get("action_on_soft"),
+        preset_source: row.get("preset_source"),
     })
 }
 
@@ -1057,6 +1063,7 @@ mod tests {
             soft_limit_usd: Some(8.0),
             action_on_hard: "block".into(),
             action_on_soft: "warn".into(),
+            preset_source: None,
         };
 
         let stored = store.upsert(&budget).await.expect("insert budget");
@@ -1091,6 +1098,7 @@ mod tests {
                 soft_limit_usd: None,
                 action_on_hard: "block".into(),
                 action_on_soft: "warn".into(),
+                preset_source: Some("preset:indie".into()),
             },
             Budget {
                 id: 0,
@@ -1101,6 +1109,7 @@ mod tests {
                 soft_limit_usd: None,
                 action_on_hard: "block".into(),
                 action_on_soft: "warn".into(),
+                preset_source: Some("preset:indie".into()),
             },
             Budget {
                 id: 0,
@@ -1111,6 +1120,7 @@ mod tests {
                 soft_limit_usd: None,
                 action_on_hard: "block".into(),
                 action_on_soft: "warn".into(),
+                preset_source: Some("preset:indie".into()),
             },
             Budget {
                 id: 0,
@@ -1121,6 +1131,7 @@ mod tests {
                 soft_limit_usd: None,
                 action_on_hard: "block".into(),
                 action_on_soft: "warn".into(),
+                preset_source: Some("preset:team".into()),
             },
         ];
 

--- a/crates/penny-types/src/lib.rs
+++ b/crates/penny-types/src/lib.rs
@@ -71,6 +71,7 @@ pub struct Budget {
     pub soft_limit_usd: Option<f64>,
     pub action_on_hard: String,
     pub action_on_soft: String,
+    pub preset_source: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -352,6 +353,7 @@ mod tests {
             soft_limit_usd: Some(8.0),
             action_on_hard: "block".into(),
             action_on_soft: "warn".into(),
+            preset_source: Some("preset:indie".into()),
         };
         assert_round_trip(&budget);
 


### PR DESCRIPTION
## Summary
Implements **#19** under **#15 (M3 Atomic Budgets)** by adding startup budget seeding from runtime config, preset source tagging, and idempotent upsert behavior.

## What changed
- Added `preset_source` to budget domain model and store persistence.
- Tagged preset-derived budgets in config loading as `preset:<name>`.
- Added proxy-side seeding helper to upsert budgets from active runtime config on startup.
- Added state builder helper that seeds budgets and wires mode/session settings from config.
- Added tests for:
  - idempotent seeding
  - preset tagging
  - safe user override over preset budgets
  - immediate evaluator visibility of seeded budgets

## Validation
- `cargo test -p penny-config`
- `cargo test -p penny-store`
- `cargo test -p penny-proxy`
- `cargo check --workspace`

Closes #19
