### PR TITLE
feat(money): replace accounting f64 with deterministic micro-USD representation (#45)

### DIFF
--- a/crates/penny-budget/src/lib.rs
+++ b/crates/penny-budget/src/lib.rs
@@ -6,8 +6,8 @@ use chrono::{Datelike, Days, Duration, TimeZone, Utc, Weekday};
 use penny_ledger::CostLedger;
 use penny_store::{BudgetRepo, EventRepo, NewEvent, SqliteStore};
 use penny_types::{
-    Budget, BudgetBlockDetail, EventType, Mode, NormalizedRequest, Reservation, RouteDecision,
-    ScopeType, Severity, WindowType,
+    Budget, BudgetBlockDetail, EventType, Mode, Money, NormalizedRequest, Reservation,
+    RouteDecision, ScopeType, Severity, WindowType,
 };
 use serde_json::json;
 use sqlx::{QueryBuilder, Row, Sqlite};
@@ -32,7 +32,7 @@ impl BudgetEvaluator {
     pub async fn evaluate(
         &self,
         request: &NormalizedRequest,
-        estimated_cost: f64,
+        estimated_cost: Money,
     ) -> RouteDecision {
         let budgets = match self.lookup_applicable_budgets(request).await {
             Ok(budgets) => budgets,
@@ -56,7 +56,7 @@ impl BudgetEvaluator {
                     "mode": self.mode_tag(),
                     "result": "allow",
                     "reason": "no_applicable_budgets",
-                    "estimated_cost_usd": estimated_cost
+                    "estimated_cost_usd": estimated_cost.to_usd()
                 }),
             )
             .await;
@@ -123,7 +123,7 @@ impl BudgetEvaluator {
                             "mode": self.mode_tag(),
                             "result": "allow",
                             "entries": entries,
-                            "estimated_cost_usd": estimated_cost
+                            "estimated_cost_usd": estimated_cost.to_usd()
                         }),
                     )
                     .await;
@@ -140,7 +140,7 @@ impl BudgetEvaluator {
                                 "allow_with_warnings"
                             },
                             "warnings": warnings,
-                            "estimated_cost_usd": estimated_cost
+                            "estimated_cost_usd": estimated_cost.to_usd()
                         }),
                     )
                     .await;
@@ -231,14 +231,16 @@ impl BudgetEvaluator {
                 continue;
             };
 
-            let Some(remaining) = remaining_map.get(&budget.id) else {
+            let Some(Some(remaining)) = remaining_map.get(&budget.id).copied() else {
                 continue;
             };
 
-            if remaining.is_finite() && *remaining < 0.0 {
-                let accumulated = limit - *remaining;
+            if remaining.is_negative() {
+                let Some(accumulated) = limit.checked_sub(remaining) else {
+                    continue;
+                };
                 warnings.push(format!(
-                    "hard limit exceeded for {} ({:?}): {:.6} / {:.6}",
+                    "hard limit exceeded for {} ({:?}): {} / {}",
                     scope_string(budget),
                     budget.window_type,
                     accumulated,
@@ -267,10 +269,7 @@ impl BudgetEvaluator {
                 continue;
             }
 
-            if !matches!(
-                remaining_map.get(&budget.id),
-                Some(remaining) if remaining.is_finite()
-            ) {
+            if !matches!(remaining_map.get(&budget.id), Some(Some(_))) {
                 lookup_budget_ids.insert(budget.id);
             }
         }
@@ -288,16 +287,16 @@ impl BudgetEvaluator {
 
             let accumulated = if let Some(limit) = budget.hard_limit_usd {
                 match remaining_map.get(&budget.id) {
-                    Some(remaining) if remaining.is_finite() => limit - *remaining,
-                    _ => *running_totals.get(&budget.id).unwrap_or(&0.0),
+                    Some(Some(remaining)) => limit.checked_sub(*remaining).unwrap_or(Money::ZERO),
+                    _ => *running_totals.get(&budget.id).unwrap_or(&Money::ZERO),
                 }
             } else {
-                *running_totals.get(&budget.id).unwrap_or(&0.0)
+                *running_totals.get(&budget.id).unwrap_or(&Money::ZERO)
             };
 
             if accumulated >= soft_limit {
                 warnings.push(format!(
-                    "soft limit reached for {} ({:?}): {:.6} / {:.6}",
+                    "soft limit reached for {} ({:?}): {} / {}",
                     scope_string(budget),
                     budget.window_type,
                     accumulated,
@@ -312,14 +311,14 @@ impl BudgetEvaluator {
     async fn latest_running_totals(
         &self,
         budget_ids: &[i64],
-    ) -> Result<HashMap<i64, f64>, sqlx::Error> {
+    ) -> Result<HashMap<i64, Money>, sqlx::Error> {
         if budget_ids.is_empty() {
             return Ok(HashMap::new());
         }
 
         let mut qb = QueryBuilder::<Sqlite>::new(
             r#"
-            SELECT budget_id, running_total
+            SELECT budget_id, running_total_micros
             FROM cost_ledger
             WHERE budget_id IN (
             "#,
@@ -340,10 +339,13 @@ impl BudgetEvaluator {
         let mut totals = HashMap::with_capacity(budget_ids.len());
         for row in rows {
             let budget_id: i64 = row.get("budget_id");
-            let running_total: f64 = row.get("running_total");
+            let running_total: i64 = row.get("running_total_micros");
             totals.entry(budget_id).or_insert(running_total);
         }
-        Ok(totals)
+        Ok(totals
+            .into_iter()
+            .map(|(budget_id, micros)| (budget_id, Money::from_micros(micros)))
+            .collect())
     }
 
     async fn failsafe_decision(
@@ -478,8 +480,8 @@ mod tests {
     async fn seed_budget(
         store: &SqliteStore,
         window_type: WindowType,
-        hard_limit: Option<f64>,
-        soft_limit: Option<f64>,
+        hard_limit: Option<Money>,
+        soft_limit: Option<Money>,
     ) -> Budget {
         BudgetRepo::upsert(
             store,
@@ -518,10 +520,18 @@ mod tests {
     #[tokio::test]
     async fn soft_limit_reached_returns_allow_with_warnings() {
         let store = setup_store().await;
-        seed_budget(&store, WindowType::Day, Some(10.0), Some(5.0)).await;
+        seed_budget(
+            &store,
+            WindowType::Day,
+            Some(Money::from_usd(10.0).expect("money")),
+            Some(Money::from_usd(5.0).expect("money")),
+        )
+        .await;
 
         let evaluator = BudgetEvaluator::new(store.clone(), Mode::Guard);
-        let decision = evaluator.evaluate(&request("req_warn"), 6.0).await;
+        let decision = evaluator
+            .evaluate(&request("req_warn"), Money::from_usd(6.0).expect("money"))
+            .await;
 
         match decision {
             RouteDecision::Allow { warnings } => {
@@ -553,15 +563,23 @@ mod tests {
     #[tokio::test]
     async fn hard_limit_exceeded_blocks_with_window_metadata() {
         let store = setup_store().await;
-        seed_budget(&store, WindowType::Day, Some(1.0), None).await;
+        seed_budget(
+            &store,
+            WindowType::Day,
+            Some(Money::from_usd(1.0).expect("money")),
+            None,
+        )
+        .await;
 
         let evaluator = BudgetEvaluator::new(store.clone(), Mode::Guard);
-        let decision = evaluator.evaluate(&request("req_block"), 2.0).await;
+        let decision = evaluator
+            .evaluate(&request("req_block"), Money::from_usd(2.0).expect("money"))
+            .await;
 
         match decision {
             RouteDecision::Block { detail, .. } => {
                 assert_eq!(detail.window, WindowType::Day);
-                assert_eq!(detail.limit_usd, 1.0);
+                assert_eq!(detail.limit_usd, Money::from_usd(1.0).expect("money"));
                 assert!(detail.resets_at.is_some());
             }
             other => panic!("unexpected decision: {other:?}"),
@@ -586,7 +604,10 @@ mod tests {
 
         let evaluator = BudgetEvaluator::new(store, Mode::Guard);
         let decision = evaluator
-            .evaluate(&request("req_guard_failsafe"), 1.0)
+            .evaluate(
+                &request("req_guard_failsafe"),
+                Money::from_usd(1.0).expect("money"),
+            )
             .await;
 
         match decision {
@@ -608,7 +629,10 @@ mod tests {
 
         let evaluator = BudgetEvaluator::new(store.clone(), Mode::Observe);
         let decision = evaluator
-            .evaluate(&request("req_observe_failsafe"), 1.0)
+            .evaluate(
+                &request("req_observe_failsafe"),
+                Money::from_usd(1.0).expect("money"),
+            )
             .await;
 
         match decision {
@@ -631,11 +655,20 @@ mod tests {
     #[tokio::test]
     async fn observe_mode_does_not_block_on_budget_denial() {
         let store = setup_store().await;
-        seed_budget(&store, WindowType::Day, Some(1.0), None).await;
+        seed_budget(
+            &store,
+            WindowType::Day,
+            Some(Money::from_usd(1.0).expect("money")),
+            None,
+        )
+        .await;
 
         let evaluator = BudgetEvaluator::new(store.clone(), Mode::Observe);
         let decision = evaluator
-            .evaluate(&request("req_observe_violation"), 2.0)
+            .evaluate(
+                &request("req_observe_violation"),
+                Money::from_usd(2.0).expect("money"),
+            )
             .await;
 
         match decision {
@@ -663,25 +696,54 @@ mod tests {
         .expect("count observe reserve rows");
         assert_eq!(reserve_count, 1);
 
-        let running_total: f64 = query_scalar(
-            "SELECT running_total FROM cost_ledger WHERE request_id = 'req_observe_violation' AND entry_type = 'reserve' LIMIT 1",
+        let running_total: i64 = query_scalar(
+            "SELECT running_total_micros FROM cost_ledger WHERE request_id = 'req_observe_violation' AND entry_type = 'reserve' LIMIT 1",
         )
         .fetch_one(store.pool())
         .await
         .expect("load observe running total");
-        assert!((running_total - 2.0).abs() < 1e-9);
+        assert_eq!(running_total, Money::from_usd(2.0).expect("money").micros());
     }
 
     #[tokio::test]
     async fn evaluator_applies_all_budget_windows_without_duplicates() {
         let store = setup_store().await;
-        seed_budget(&store, WindowType::Day, Some(100.0), None).await;
-        seed_budget(&store, WindowType::Week, Some(100.0), None).await;
-        seed_budget(&store, WindowType::Month, Some(100.0), None).await;
-        seed_budget(&store, WindowType::Total, Some(100.0), None).await;
+        seed_budget(
+            &store,
+            WindowType::Day,
+            Some(Money::from_usd(100.0).expect("money")),
+            None,
+        )
+        .await;
+        seed_budget(
+            &store,
+            WindowType::Week,
+            Some(Money::from_usd(100.0).expect("money")),
+            None,
+        )
+        .await;
+        seed_budget(
+            &store,
+            WindowType::Month,
+            Some(Money::from_usd(100.0).expect("money")),
+            None,
+        )
+        .await;
+        seed_budget(
+            &store,
+            WindowType::Total,
+            Some(Money::from_usd(100.0).expect("money")),
+            None,
+        )
+        .await;
 
         let evaluator = BudgetEvaluator::new(store.clone(), Mode::Guard);
-        let decision = evaluator.evaluate(&request("req_windows"), 1.0).await;
+        let decision = evaluator
+            .evaluate(
+                &request("req_windows"),
+                Money::from_usd(1.0).expect("money"),
+            )
+            .await;
         assert!(matches!(decision, RouteDecision::Allow { .. }));
 
         let reserve_count: i64 = query_scalar(

--- a/crates/penny-cost/src/lib.rs
+++ b/crates/penny-cost/src/lib.rs
@@ -4,7 +4,7 @@ use std::{fs, path::Path};
 
 use chrono::{DateTime, Utc};
 use penny_store::{NewPricebookEntry, PricebookRepo, SqliteStore, StoreError};
-use penny_types::{Confidence, CostRange, TaskType, UsageSource};
+use penny_types::{Confidence, CostRange, Money, MoneyError, TaskType, UsageSource};
 use serde::Deserialize;
 use serde_json::Value;
 use thiserror::Error;
@@ -24,6 +24,10 @@ pub enum CostError {
     InvalidDatetime { field: &'static str, value: String },
     #[error("no active pricebook entry found for model `{0}`")]
     PriceNotFound(String),
+    #[error("money conversion error: {0}")]
+    Money(#[from] MoneyError),
+    #[error("money arithmetic overflow")]
+    MoneyOverflow,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -48,9 +52,9 @@ impl<'a, R: PricebookRepo> PricingEngine<'a, R> {
         model_id: &str,
         input_tokens: u64,
         output_tokens: u64,
-    ) -> Result<f64, CostError> {
+    ) -> Result<Money, CostError> {
         if input_tokens == 0 && output_tokens == 0 {
-            return Ok(0.0);
+            return Ok(Money::ZERO);
         }
 
         let price = self
@@ -59,9 +63,14 @@ impl<'a, R: PricebookRepo> PricingEngine<'a, R> {
             .await?
             .ok_or_else(|| CostError::PriceNotFound(model_id.to_string()))?;
 
-        let input_cost = (input_tokens as f64 * price.input_per_mtok) / 1_000_000.0;
-        let output_cost = (output_tokens as f64 * price.output_per_mtok) / 1_000_000.0;
-        Ok(input_cost + output_cost)
+        let input_rate = Money::from_usd(price.input_per_mtok)?;
+        let output_rate = Money::from_usd(price.output_per_mtok)?;
+
+        let input_cost = prorate_mtok(input_tokens, input_rate)?;
+        let output_cost = prorate_mtok(output_tokens, output_rate)?;
+        input_cost
+            .checked_add(output_cost)
+            .ok_or(CostError::MoneyOverflow)
     }
 
     /// Estimate input/output tokens from OpenAI-compatible `messages`.
@@ -104,6 +113,7 @@ impl<'a, R: PricebookRepo> PricingEngine<'a, R> {
         let one_round = self
             .calculate(model_id, context_tokens, output_tokens)
             .await?;
+        let one_round_usd = one_round.to_usd();
 
         let (rounds, margin, confidence) = match task_type {
             TaskType::SinglePass => (1.0, 0.30, Confidence::High),
@@ -111,7 +121,7 @@ impl<'a, R: PricebookRepo> PricingEngine<'a, R> {
             TaskType::AgentTask => (5.0, 1.00, Confidence::Low),
         };
 
-        let center = one_round * rounds;
+        let center = one_round_usd * rounds;
         let min = (center * (1.0 - margin)).max(0.0);
         let max = center * (1.0 + margin);
 
@@ -160,6 +170,13 @@ pub fn estimate_tokens(messages: &Value) -> TokenEstimate {
 
 fn estimate_output_tokens(input_tokens: u64) -> u64 {
     ((input_tokens as f64 * 0.3).min(4096.0)).round() as u64
+}
+
+fn prorate_mtok(tokens: u64, usd_per_mtok: Money) -> Result<Money, CostError> {
+    let numerator = i128::from(tokens) * i128::from(usd_per_mtok.micros());
+    let micros = (numerator + 500_000) / 1_000_000;
+    let micros_i64 = i64::try_from(micros).map_err(|_| CostError::MoneyOverflow)?;
+    Ok(Money::from_micros(micros_i64))
 }
 
 fn heuristic_chars_to_tokens(chars: usize) -> u64 {
@@ -352,7 +369,7 @@ mod tests {
             .await
             .expect("calculate");
 
-        approx_eq(cost, 18.0, 1e-9);
+        assert_eq!(cost, Money::from_usd(18.0).expect("money"));
     }
 
     #[tokio::test]

--- a/crates/penny-ledger/src/lib.rs
+++ b/crates/penny-ledger/src/lib.rs
@@ -3,7 +3,7 @@
 use std::collections::HashMap;
 
 use penny_store::{SqliteStore, StoreError};
-use penny_types::{Budget, BudgetRemaining, Reservation};
+use penny_types::{Budget, BudgetRemaining, Money, Reservation};
 use sqlx::{query, query_scalar, Row};
 use thiserror::Error;
 
@@ -26,8 +26,8 @@ pub struct CostLedger {
 struct LedgerRow {
     id: i64,
     budget_id: i64,
-    amount_usd: f64,
-    running_total: f64,
+    amount_usd: Money,
+    running_total: Money,
 }
 
 impl CostLedger {
@@ -43,7 +43,7 @@ impl CostLedger {
         &self,
         request_id: &str,
         budgets: &[Budget],
-        estimated_cost: f64,
+        estimated_cost: Money,
     ) -> Result<Reservation, LedgerError> {
         self.reserve_internal(request_id, budgets, estimated_cost, true)
             .await
@@ -53,7 +53,7 @@ impl CostLedger {
         &self,
         request_id: &str,
         budgets: &[Budget],
-        estimated_cost: f64,
+        estimated_cost: Money,
     ) -> Result<Reservation, LedgerError> {
         self.reserve_internal(request_id, budgets, estimated_cost, false)
             .await
@@ -63,15 +63,15 @@ impl CostLedger {
         &self,
         request_id: &str,
         budgets: &[Budget],
-        estimated_cost: f64,
+        estimated_cost: Money,
         enforce_hard_limits: bool,
     ) -> Result<Reservation, LedgerError> {
         if request_id.trim().is_empty() {
             return Err(LedgerError::InvalidRequest("request_id must not be empty"));
         }
-        if !estimated_cost.is_finite() || estimated_cost < 0.0 {
+        if estimated_cost.is_negative() {
             return Err(LedgerError::InvalidRequest(
-                "estimated_cost must be a finite non-negative number",
+                "estimated_cost must be non-negative",
             ));
         }
 
@@ -97,7 +97,12 @@ impl CostLedger {
 
         for budget in budgets {
             let current_total = latest_running_total(&mut tx, budget.id).await?;
-            let new_total = current_total + estimated_cost;
+            let Some(new_total) = current_total.checked_add(estimated_cost) else {
+                tx.rollback().await?;
+                return Err(LedgerError::InvalidRequest(
+                    "running_total overflow while reserving budget",
+                ));
+            };
             if enforce_hard_limits {
                 if let Some(limit) = budget.hard_limit_usd {
                     if new_total > limit {
@@ -107,7 +112,7 @@ impl CostLedger {
                             accumulated: new_total,
                             limit,
                             reason: format!(
-                                "budget id {} exceeded hard limit: {:.6} > {:.6}",
+                                "budget id {} exceeded hard limit: {} > {}",
                                 budget.id, new_total, limit
                             ),
                         });
@@ -129,8 +134,7 @@ impl CostLedger {
                 budget_id: budget.id,
                 remaining_usd: budget
                     .hard_limit_usd
-                    .map(|limit| limit - new_total)
-                    .unwrap_or(f64::INFINITY),
+                    .and_then(|limit| limit.checked_sub(new_total)),
             });
         }
 
@@ -144,14 +148,14 @@ impl CostLedger {
     pub async fn reconcile(
         &self,
         request_id: &str,
-        actual_cost: f64,
+        actual_cost: Money,
     ) -> Result<Vec<i64>, LedgerError> {
         if request_id.trim().is_empty() {
             return Err(LedgerError::InvalidRequest("request_id must not be empty"));
         }
-        if !actual_cost.is_finite() || actual_cost < 0.0 {
+        if actual_cost.is_negative() {
             return Err(LedgerError::InvalidRequest(
-                "actual_cost must be a finite non-negative number",
+                "actual_cost must be non-negative",
             ));
         }
 
@@ -183,9 +187,19 @@ impl CostLedger {
         for row in reserve_rows {
             let budget_id = row.budget_id;
             let reserved_amount = row.amount_usd;
-            let diff = actual_cost - reserved_amount;
+            let Some(diff) = actual_cost.checked_sub(reserved_amount) else {
+                tx.rollback().await?;
+                return Err(LedgerError::InvalidRequest(
+                    "reconcile diff overflow for request",
+                ));
+            };
             let current_total = latest_running_total(&mut tx, budget_id).await?;
-            let new_total = current_total + diff;
+            let Some(new_total) = current_total.checked_add(diff) else {
+                tx.rollback().await?;
+                return Err(LedgerError::InvalidRequest(
+                    "running_total overflow while reconciling",
+                ));
+            };
             let entry_id =
                 insert_ledger_entry(&mut tx, request_id, "reconcile", budget_id, diff, new_total)
                     .await?;
@@ -229,9 +243,19 @@ impl CostLedger {
         for row in reserve_rows {
             let budget_id = row.budget_id;
             let reserved_amount = row.amount_usd;
-            let release_amount = -reserved_amount;
+            let Some(release_amount) = Money::ZERO.checked_sub(reserved_amount) else {
+                tx.rollback().await?;
+                return Err(LedgerError::InvalidRequest(
+                    "release amount overflow for request",
+                ));
+            };
             let current_total = latest_running_total(&mut tx, budget_id).await?;
-            let new_total = current_total + release_amount;
+            let Some(new_total) = current_total.checked_add(release_amount) else {
+                tx.rollback().await?;
+                return Err(LedgerError::InvalidRequest(
+                    "running_total overflow while releasing",
+                ));
+            };
             let entry_id = insert_ledger_entry(
                 &mut tx,
                 request_id,
@@ -251,7 +275,7 @@ impl CostLedger {
 
 fn reservation_from_existing(
     budgets: &[Budget],
-    estimated_cost: f64,
+    estimated_cost: Money,
     rows: &[LedgerRow],
 ) -> Result<Reservation, LedgerError> {
     if rows.len() != budgets.len() {
@@ -277,7 +301,7 @@ fn reservation_from_existing(
             ));
         };
 
-        if (row.amount_usd - estimated_cost).abs() > 1e-9 {
+        if row.amount_usd != estimated_cost {
             return Err(LedgerError::InvalidRequest(
                 "estimated_cost does not match existing reservation",
             ));
@@ -287,8 +311,7 @@ fn reservation_from_existing(
             budget_id: budget.id,
             remaining_usd: budget
                 .hard_limit_usd
-                .map(|limit| limit - row.running_total)
-                .unwrap_or(f64::INFINITY),
+                .and_then(|limit| limit.checked_sub(row.running_total)),
         });
     }
 
@@ -301,10 +324,10 @@ fn reservation_from_existing(
 async fn latest_running_total(
     tx: &mut sqlx::Transaction<'_, sqlx::Sqlite>,
     budget_id: i64,
-) -> Result<f64, sqlx::Error> {
+) -> Result<Money, sqlx::Error> {
     query_scalar(
         r#"
-        SELECT running_total
+        SELECT running_total_micros
         FROM cost_ledger
         WHERE budget_id = ?1
         ORDER BY id DESC
@@ -314,7 +337,7 @@ async fn latest_running_total(
     .bind(budget_id)
     .fetch_optional(&mut **tx)
     .await
-    .map(|value: Option<f64>| value.unwrap_or(0.0))
+    .map(|value: Option<i64>| Money::from_micros(value.unwrap_or(0)))
 }
 
 async fn insert_ledger_entry(
@@ -322,22 +345,24 @@ async fn insert_ledger_entry(
     request_id: &str,
     entry_type: &'static str,
     budget_id: i64,
-    amount_usd: f64,
-    running_total: f64,
+    amount_usd: Money,
+    running_total: Money,
 ) -> Result<i64, sqlx::Error> {
     let result = query(
         r#"
         INSERT INTO cost_ledger (
-            request_id, entry_type, budget_id, amount_usd, running_total
+            request_id, entry_type, budget_id, amount_usd, amount_micros, running_total, running_total_micros
         )
-        VALUES (?1, ?2, ?3, ?4, ?5)
+        VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)
         "#,
     )
     .bind(request_id)
     .bind(entry_type)
     .bind(budget_id)
-    .bind(amount_usd)
-    .bind(running_total)
+    .bind(amount_usd.to_usd())
+    .bind(amount_usd.micros())
+    .bind(running_total.to_usd())
+    .bind(running_total.micros())
     .execute(&mut **tx)
     .await?;
 
@@ -357,7 +382,7 @@ async fn request_entries_by_type(
 ) -> Result<Vec<LedgerRow>, sqlx::Error> {
     let rows = query(
         r#"
-        SELECT id, budget_id, amount_usd, running_total
+        SELECT id, budget_id, amount_micros, running_total_micros
         FROM cost_ledger
         WHERE request_id = ?1 AND entry_type = ?2
         ORDER BY id
@@ -373,8 +398,8 @@ async fn request_entries_by_type(
         entries.push(LedgerRow {
             id: row.get("id"),
             budget_id: row.get("budget_id"),
-            amount_usd: row.get("amount_usd"),
-            running_total: row.get("running_total"),
+            amount_usd: Money::from_micros(row.get("amount_micros")),
+            running_total: Money::from_micros(row.get("running_total_micros")),
         });
     }
     Ok(entries)
@@ -415,7 +440,7 @@ mod tests {
             .expect("create in-memory store")
     }
 
-    async fn insert_budget(store: &SqliteStore, hard_limit: Option<f64>) -> Budget {
+    async fn insert_budget(store: &SqliteStore, hard_limit: Option<Money>) -> Budget {
         BudgetRepo::upsert(
             store,
             &Budget {
@@ -437,11 +462,15 @@ mod tests {
     #[tokio::test]
     async fn reserve_grants_and_persists_running_total() {
         let store = setup_store().await;
-        let budget = insert_budget(&store, Some(10.0)).await;
+        let budget = insert_budget(&store, Some(Money::from_usd(10.0).expect("money"))).await;
         let ledger = CostLedger::new(store.clone());
 
         let reservation = ledger
-            .reserve("req_01", std::slice::from_ref(&budget), 2.5)
+            .reserve(
+                "req_01",
+                std::slice::from_ref(&budget),
+                Money::from_usd(2.5).expect("money"),
+            )
             .await
             .expect("reserve should succeed");
 
@@ -453,14 +482,17 @@ mod tests {
                 assert_eq!(entries.len(), 1);
                 assert_eq!(remaining_by_budget.len(), 1);
                 assert_eq!(remaining_by_budget[0].budget_id, budget.id);
-                assert!((remaining_by_budget[0].remaining_usd - 7.5).abs() < 1e-9);
+                assert_eq!(
+                    remaining_by_budget[0].remaining_usd,
+                    Some(Money::from_usd(7.5).expect("money"))
+                );
             }
             Reservation::Denied { .. } => panic!("reservation unexpectedly denied"),
         }
 
-        let running_total: f64 = query_scalar(
+        let running_total: i64 = query_scalar(
             r#"
-            SELECT running_total
+            SELECT running_total_micros
             FROM cost_ledger
             WHERE request_id = 'req_01' AND entry_type = 'reserve'
             LIMIT 1
@@ -469,23 +501,29 @@ mod tests {
         .fetch_one(store.pool())
         .await
         .expect("load running_total");
-        assert!((running_total - 2.5).abs() < 1e-9);
+        assert_eq!(running_total, Money::from_usd(2.5).expect("money").micros());
     }
 
     #[tokio::test]
     async fn reserve_denied_rolls_back_all_budget_rows() {
         let store = setup_store().await;
-        let budget_a = insert_budget(&store, Some(10.0)).await;
-        let budget_b = insert_budget(&store, Some(1.0)).await;
+        let budget_a = insert_budget(&store, Some(Money::from_usd(10.0).expect("money"))).await;
+        let budget_b = insert_budget(&store, Some(Money::from_usd(1.0).expect("money"))).await;
         let ledger = CostLedger::new(store.clone());
 
         let reservation = ledger
-            .reserve("req_denied", &[budget_a, budget_b], 2.0)
+            .reserve(
+                "req_denied",
+                &[budget_a, budget_b],
+                Money::from_usd(2.0).expect("money"),
+            )
             .await
             .expect("reserve should return denied, not error");
 
         match reservation {
-            Reservation::Denied { limit, .. } => assert_eq!(limit, 1.0),
+            Reservation::Denied { limit, .. } => {
+                assert_eq!(limit, Money::from_usd(1.0).expect("money"))
+            }
             Reservation::Granted { .. } => panic!("reservation unexpectedly granted"),
         }
 
@@ -500,11 +538,15 @@ mod tests {
     #[tokio::test]
     async fn reserve_allow_over_limit_persists_entries_in_observe_style_flow() {
         let store = setup_store().await;
-        let budget = insert_budget(&store, Some(1.0)).await;
+        let budget = insert_budget(&store, Some(Money::from_usd(1.0).expect("money"))).await;
         let ledger = CostLedger::new(store.clone());
 
         let reservation = ledger
-            .reserve_allow_over_limit("req_observe", std::slice::from_ref(&budget), 2.0)
+            .reserve_allow_over_limit(
+                "req_observe",
+                std::slice::from_ref(&budget),
+                Money::from_usd(2.0).expect("money"),
+            )
             .await
             .expect("reserve allow over limit should succeed");
 
@@ -515,14 +557,17 @@ mod tests {
             } => {
                 assert_eq!(entries.len(), 1);
                 assert_eq!(remaining_by_budget.len(), 1);
-                assert!(remaining_by_budget[0].remaining_usd < 0.0);
+                assert_eq!(
+                    remaining_by_budget[0].remaining_usd,
+                    Some(Money::from_usd(-1.0).expect("money"))
+                );
             }
             Reservation::Denied { .. } => panic!("reservation should not deny in allow-over-limit"),
         }
 
         let row = query(
             r#"
-            SELECT amount_usd, running_total
+            SELECT amount_micros, running_total_micros
             FROM cost_ledger
             WHERE request_id = 'req_observe' AND entry_type = 'reserve'
             LIMIT 1
@@ -532,33 +577,37 @@ mod tests {
         .await
         .expect("load observe reserve row");
 
-        let amount: f64 = row.get("amount_usd");
-        let running_total: f64 = row.get("running_total");
-        assert!((amount - 2.0).abs() < 1e-9);
-        assert!((running_total - 2.0).abs() < 1e-9);
+        let amount: i64 = row.get("amount_micros");
+        let running_total: i64 = row.get("running_total_micros");
+        assert_eq!(amount, Money::from_usd(2.0).expect("money").micros());
+        assert_eq!(running_total, Money::from_usd(2.0).expect("money").micros());
     }
 
     #[tokio::test]
     async fn reconcile_adds_diff_entries_against_reserves() {
         let store = setup_store().await;
-        let budget = insert_budget(&store, Some(20.0)).await;
+        let budget = insert_budget(&store, Some(Money::from_usd(20.0).expect("money"))).await;
         let ledger = CostLedger::new(store.clone());
 
         let reserve_result = ledger
-            .reserve("req_reconcile", std::slice::from_ref(&budget), 2.0)
+            .reserve(
+                "req_reconcile",
+                std::slice::from_ref(&budget),
+                Money::from_usd(2.0).expect("money"),
+            )
             .await
             .expect("reserve");
         assert!(matches!(reserve_result, Reservation::Granted { .. }));
 
         let ids = ledger
-            .reconcile("req_reconcile", 3.5)
+            .reconcile("req_reconcile", Money::from_usd(3.5).expect("money"))
             .await
             .expect("reconcile");
         assert_eq!(ids.len(), 1);
 
         let row = query(
             r#"
-            SELECT amount_usd, running_total
+            SELECT amount_micros, running_total_micros
             FROM cost_ledger
             WHERE request_id = 'req_reconcile' AND entry_type = 'reconcile'
             LIMIT 1
@@ -568,20 +617,24 @@ mod tests {
         .await
         .expect("load reconcile row");
 
-        let amount: f64 = row.get("amount_usd");
-        let running_total: f64 = row.get("running_total");
-        assert!((amount - 1.5).abs() < 1e-9);
-        assert!((running_total - 3.5).abs() < 1e-9);
+        let amount: i64 = row.get("amount_micros");
+        let running_total: i64 = row.get("running_total_micros");
+        assert_eq!(amount, Money::from_usd(1.5).expect("money").micros());
+        assert_eq!(running_total, Money::from_usd(3.5).expect("money").micros());
     }
 
     #[tokio::test]
     async fn release_reverts_reserved_amount() {
         let store = setup_store().await;
-        let budget = insert_budget(&store, Some(20.0)).await;
+        let budget = insert_budget(&store, Some(Money::from_usd(20.0).expect("money"))).await;
         let ledger = CostLedger::new(store.clone());
 
         let reserve_result = ledger
-            .reserve("req_release", std::slice::from_ref(&budget), 2.0)
+            .reserve(
+                "req_release",
+                std::slice::from_ref(&budget),
+                Money::from_usd(2.0).expect("money"),
+            )
             .await
             .expect("reserve");
         assert!(matches!(reserve_result, Reservation::Granted { .. }));
@@ -591,7 +644,7 @@ mod tests {
 
         let row = query(
             r#"
-            SELECT amount_usd, running_total
+            SELECT amount_micros, running_total_micros
             FROM cost_ledger
             WHERE request_id = 'req_release' AND entry_type = 'release'
             LIMIT 1
@@ -601,24 +654,32 @@ mod tests {
         .await
         .expect("load release row");
 
-        let amount: f64 = row.get("amount_usd");
-        let running_total: f64 = row.get("running_total");
-        assert!((amount + 2.0).abs() < 1e-9);
-        assert!(running_total.abs() < 1e-9);
+        let amount: i64 = row.get("amount_micros");
+        let running_total: i64 = row.get("running_total_micros");
+        assert_eq!(amount, Money::from_usd(-2.0).expect("money").micros());
+        assert_eq!(running_total, Money::ZERO.micros());
     }
 
     #[tokio::test]
     async fn reserve_is_idempotent_for_same_request_id() {
         let store = setup_store().await;
-        let budget = insert_budget(&store, Some(10.0)).await;
+        let budget = insert_budget(&store, Some(Money::from_usd(10.0).expect("money"))).await;
         let ledger = CostLedger::new(store.clone());
 
         let first = ledger
-            .reserve("req_idempotent_reserve", std::slice::from_ref(&budget), 2.0)
+            .reserve(
+                "req_idempotent_reserve",
+                std::slice::from_ref(&budget),
+                Money::from_usd(2.0).expect("money"),
+            )
             .await
             .expect("first reserve");
         let second = ledger
-            .reserve("req_idempotent_reserve", std::slice::from_ref(&budget), 2.0)
+            .reserve(
+                "req_idempotent_reserve",
+                std::slice::from_ref(&budget),
+                Money::from_usd(2.0).expect("money"),
+            )
             .await
             .expect("second reserve should be idempotent");
 
@@ -651,24 +712,30 @@ mod tests {
     #[tokio::test]
     async fn reconcile_is_idempotent_for_same_request_id() {
         let store = setup_store().await;
-        let budget = insert_budget(&store, Some(20.0)).await;
+        let budget = insert_budget(&store, Some(Money::from_usd(20.0).expect("money"))).await;
         let ledger = CostLedger::new(store.clone());
 
         ledger
             .reserve(
                 "req_idempotent_reconcile",
                 std::slice::from_ref(&budget),
-                2.0,
+                Money::from_usd(2.0).expect("money"),
             )
             .await
             .expect("reserve");
 
         let first = ledger
-            .reconcile("req_idempotent_reconcile", 3.0)
+            .reconcile(
+                "req_idempotent_reconcile",
+                Money::from_usd(3.0).expect("money"),
+            )
             .await
             .expect("first reconcile");
         let second = ledger
-            .reconcile("req_idempotent_reconcile", 3.0)
+            .reconcile(
+                "req_idempotent_reconcile",
+                Money::from_usd(3.0).expect("money"),
+            )
             .await
             .expect("second reconcile should be idempotent");
 
@@ -687,11 +754,15 @@ mod tests {
     #[tokio::test]
     async fn release_is_idempotent_for_same_request_id() {
         let store = setup_store().await;
-        let budget = insert_budget(&store, Some(20.0)).await;
+        let budget = insert_budget(&store, Some(Money::from_usd(20.0).expect("money"))).await;
         let ledger = CostLedger::new(store.clone());
 
         ledger
-            .reserve("req_idempotent_release", std::slice::from_ref(&budget), 2.0)
+            .reserve(
+                "req_idempotent_release",
+                std::slice::from_ref(&budget),
+                Money::from_usd(2.0).expect("money"),
+            )
             .await
             .expect("reserve");
 
@@ -719,14 +790,14 @@ mod tests {
     #[tokio::test]
     async fn reconcile_after_release_is_rejected() {
         let store = setup_store().await;
-        let budget = insert_budget(&store, Some(20.0)).await;
+        let budget = insert_budget(&store, Some(Money::from_usd(20.0).expect("money"))).await;
         let ledger = CostLedger::new(store);
 
         ledger
             .reserve(
                 "req_conflict_reconcile_after_release",
                 std::slice::from_ref(&budget),
-                2.0,
+                Money::from_usd(2.0).expect("money"),
             )
             .await
             .expect("reserve");
@@ -736,7 +807,10 @@ mod tests {
             .expect("release");
 
         let err = ledger
-            .reconcile("req_conflict_reconcile_after_release", 3.0)
+            .reconcile(
+                "req_conflict_reconcile_after_release",
+                Money::from_usd(3.0).expect("money"),
+            )
             .await
             .expect_err("reconcile after release should fail");
 
@@ -749,19 +823,22 @@ mod tests {
     #[tokio::test]
     async fn release_after_reconcile_is_rejected() {
         let store = setup_store().await;
-        let budget = insert_budget(&store, Some(20.0)).await;
+        let budget = insert_budget(&store, Some(Money::from_usd(20.0).expect("money"))).await;
         let ledger = CostLedger::new(store);
 
         ledger
             .reserve(
                 "req_conflict_release_after_reconcile",
                 std::slice::from_ref(&budget),
-                2.0,
+                Money::from_usd(2.0).expect("money"),
             )
             .await
             .expect("reserve");
         ledger
-            .reconcile("req_conflict_release_after_reconcile", 3.0)
+            .reconcile(
+                "req_conflict_release_after_reconcile",
+                Money::from_usd(3.0).expect("money"),
+            )
             .await
             .expect("reconcile");
 

--- a/crates/penny-proxy/src/lib.rs
+++ b/crates/penny-proxy/src/lib.rs
@@ -28,8 +28,8 @@ use penny_store::{
     BudgetRepo, NewRequest, ProjectRepo, RequestRepo, SessionRepo, SqliteStore, UsageRecord,
 };
 use penny_types::{
-    Budget, BudgetBlockDetail, Mode, NormalizedRequest, ResponseBody, RouteDecision, ScopeType,
-    UsageSource, WindowType,
+    Budget, BudgetBlockDetail, Mode, Money, NormalizedRequest, ResponseBody, RouteDecision,
+    ScopeType, UsageSource, WindowType,
 };
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
@@ -173,7 +173,7 @@ struct NormalizedUsage {
 
 #[derive(Debug, Clone, Copy)]
 struct BudgetEnforcementContext {
-    estimated_cost_usd: f64,
+    estimated_cost_usd: Money,
     reserve_persisted: bool,
 }
 
@@ -270,7 +270,7 @@ async fn post_chat_completions(
                     enforcement
                         .as_ref()
                         .map(|ctx| ctx.estimated_cost_usd)
-                        .unwrap_or(0.0)
+                        .unwrap_or(Money::ZERO)
                 });
             if let Some(context) = enforcement {
                 if let Err(message) = reconcile_after_dispatch(
@@ -312,7 +312,7 @@ async fn post_chat_completions(
                         enforcement
                             .as_ref()
                             .map(|ctx| ctx.estimated_cost_usd)
-                            .unwrap_or(0.0)
+                            .unwrap_or(Money::ZERO)
                     });
                 if let Some(context) = enforcement {
                     if let Err(message) = reconcile_after_dispatch(
@@ -614,8 +614,12 @@ fn map_config_budget(budget: &RuntimeBudgetConfig) -> Budget {
         scope_type: scope_type_from_config(&budget.scope_type),
         scope_id: budget.scope_id.clone(),
         window_type: window_type_from_config(&budget.window_type),
-        hard_limit_usd: budget.hard_limit_usd,
-        soft_limit_usd: budget.soft_limit_usd,
+        hard_limit_usd: budget
+            .hard_limit_usd
+            .and_then(|value| Money::from_usd(value).ok()),
+        soft_limit_usd: budget
+            .soft_limit_usd
+            .and_then(|value| Money::from_usd(value).ok()),
         action_on_hard: budget.action_on_hard.clone(),
         action_on_soft: budget.action_on_soft.clone(),
         preset_source: budget.preset_source.clone(),
@@ -671,7 +675,7 @@ async fn evaluate_budget_before_dispatch(
 
     if !has_budgets {
         return Ok(Some(BudgetEnforcementContext {
-            estimated_cost_usd: 0.0,
+            estimated_cost_usd: Money::ZERO,
             reserve_persisted: false,
         }));
     }
@@ -687,7 +691,7 @@ async fn evaluate_budget_before_dispatch(
                     None,
                 ));
             }
-            0.0
+            Money::ZERO
         }
     };
 
@@ -702,7 +706,7 @@ async fn evaluate_budget_before_dispatch(
         }
         RouteDecision::Block { reason, detail } => {
             let message = format!(
-                "{} ({:?}) exceeded: {:.6} / {:.6} - {reason}",
+                "{} ({:?}) exceeded: {} / {} - {reason}",
                 detail.scope, detail.window, detail.accumulated_usd, detail.limit_usd
             );
             Err(budget_error_response(
@@ -732,9 +736,9 @@ async fn evaluate_budget_before_dispatch(
 async fn estimated_request_cost_usd(
     state: &ProxyState,
     request: &NormalizedRequest,
-) -> Result<f64, String> {
+) -> Result<Money, String> {
     let Some(store) = &state.store else {
-        return Ok(0.0);
+        return Ok(Money::ZERO);
     };
     PricingEngine::new(store)
         .calculate(
@@ -750,9 +754,9 @@ async fn actual_usage_cost_usd(
     state: &ProxyState,
     request: &NormalizedRequest,
     usage: &NormalizedUsage,
-) -> Result<f64, String> {
+) -> Result<Money, String> {
     let Some(store) = &state.store else {
-        return Ok(0.0);
+        return Ok(Money::ZERO);
     };
     PricingEngine::new(store)
         .calculate(
@@ -786,7 +790,7 @@ async fn has_any_budget(store: &SqliteStore) -> Result<bool, String> {
 async fn reconcile_after_dispatch(
     state: &ProxyState,
     request_id: &str,
-    usage_cost_usd: f64,
+    usage_cost_usd: Money,
     reserve_persisted: bool,
 ) -> Result<(), String> {
     if !reserve_persisted {
@@ -820,7 +824,7 @@ async fn persist_request_and_usage(
     state: &ProxyState,
     normalized: &NormalizedRequest,
     usage: &NormalizedUsage,
-    cost_usd: f64,
+    cost_usd: Money,
 ) -> Result<(), String> {
     let Some(store) = &state.store else {
         return Ok(());
@@ -977,7 +981,7 @@ mod tests {
     use penny_config::{load_config, LoadOptions};
     use penny_cost::import_pricebook_files;
     use penny_store::BudgetRepo;
-    use penny_types::{Budget, RouteDecision, ScopeType, WindowType};
+    use penny_types::{Budget, Money, RouteDecision, ScopeType, WindowType};
     use sqlx::Row;
     use std::fs;
     use std::path::PathBuf;
@@ -1012,7 +1016,7 @@ mod tests {
         .expect("import pricebooks");
     }
 
-    async fn seed_global_day_budget(store: &SqliteStore, hard_limit_usd: f64) {
+    async fn seed_global_day_budget(store: &SqliteStore, hard_limit_usd: Money) {
         BudgetRepo::upsert(
             store,
             &Budget {
@@ -1121,7 +1125,10 @@ action_on_soft = "warn"
             .expect("list all budgets");
         assert_eq!(all.len(), 1);
         assert_eq!(all[0].window_type, WindowType::Day);
-        assert_eq!(all[0].hard_limit_usd, Some(7.0));
+        assert_eq!(
+            all[0].hard_limit_usd,
+            Some(Money::from_usd(7.0).expect("money"))
+        );
         assert_eq!(all[0].preset_source, None);
     }
 
@@ -1143,7 +1150,10 @@ action_on_soft = "warn"
 
         let evaluator = BudgetEvaluator::new(store, Mode::Guard);
         let decision = evaluator
-            .evaluate(&budget_request("req_seeded_eval"), 11.0)
+            .evaluate(
+                &budget_request("req_seeded_eval"),
+                Money::from_usd(11.0).expect("money"),
+            )
             .await;
         assert!(matches!(decision, RouteDecision::Block { .. }));
     }
@@ -1515,7 +1525,7 @@ action_on_soft = "warn"
     async fn over_budget_request_returns_structured_402_and_never_429() {
         let (app, store) = app_with_store().await;
         seed_pricebooks(&store).await;
-        seed_global_day_budget(&store, 0.0).await;
+        seed_global_day_budget(&store, Money::from_usd(0.0).expect("money")).await;
 
         let request = Request::builder()
             .method("POST")
@@ -1557,7 +1567,7 @@ action_on_soft = "warn"
     async fn successful_dispatch_persists_reserve_then_reconcile() {
         let (app, store) = app_with_store().await;
         seed_pricebooks(&store).await;
-        seed_global_day_budget(&store, 10.0).await;
+        seed_global_day_budget(&store, Money::from_usd(10.0).expect("money")).await;
 
         let request = Request::builder()
             .method("POST")
@@ -1596,7 +1606,7 @@ action_on_soft = "warn"
             .await
             .expect("create in-memory store");
         seed_pricebooks(&store).await;
-        seed_global_day_budget(&store, 10.0).await;
+        seed_global_day_budget(&store, Money::from_usd(10.0).expect("money")).await;
 
         let failing_provider = MockProvider::new(MockProviderConfig {
             supported_models: Vec::new(),

--- a/crates/penny-store/src/lib.rs
+++ b/crates/penny-store/src/lib.rs
@@ -4,8 +4,8 @@ use std::{path::Path, str::FromStr};
 
 use chrono::{DateTime, NaiveDateTime, Utc};
 use penny_types::{
-    AccountedUsage, Budget, Event, EventType, ProjectId, RequestId, ScopeType, SessionId, Severity,
-    UsageSource, WindowType,
+    AccountedUsage, Budget, Event, EventType, Money, ProjectId, RequestId, ScopeType, SessionId,
+    Severity, UsageSource, WindowType,
 };
 use serde_json::Value;
 use sqlx::{
@@ -115,7 +115,7 @@ pub struct UsageRecord {
     pub request_id: RequestId,
     pub input_tokens: u64,
     pub output_tokens: u64,
-    pub cost_usd: f64,
+    pub cost_usd: Money,
     pub source: UsageSource,
     pub pricing_snapshot: Value,
 }
@@ -421,15 +421,16 @@ impl RequestRepo for SqliteStore {
         sqlx::query(
             r#"
             INSERT INTO request_usage (
-                request_id, input_tokens, output_tokens, cost_usd, pricing_snapshot, source
+                request_id, input_tokens, output_tokens, cost_usd, cost_micros, pricing_snapshot, source
             )
-            VALUES (?1, ?2, ?3, ?4, ?5, ?6)
+            VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)
             "#,
         )
         .bind(&usage.request_id)
         .bind(i64_from_u64(usage.input_tokens))
         .bind(i64_from_u64(usage.output_tokens))
-        .bind(usage.cost_usd)
+        .bind(usage.cost_usd.to_usd())
+        .bind(usage.cost_usd.micros())
         .bind(usage.pricing_snapshot.to_string())
         .bind(usage_source_to_db(&usage.source))
         .execute(&self.pool)
@@ -449,7 +450,7 @@ impl BudgetRepo for SqliteStore {
         let window_type_db = window_type_to_db(&window_type);
         let rows = sqlx::query(
             r#"
-            SELECT id, scope_type, scope_id, window_type, hard_limit_usd, soft_limit_usd, action_on_hard, action_on_soft, preset_source
+            SELECT id, scope_type, scope_id, window_type, hard_limit_micros, soft_limit_micros, action_on_hard, action_on_soft, preset_source
             FROM budgets
             WHERE window_type = ?1
               AND (
@@ -475,7 +476,7 @@ impl BudgetRepo for SqliteStore {
     ) -> Result<Vec<Budget>, StoreError> {
         let rows = sqlx::query(
             r#"
-            SELECT id, scope_type, scope_id, window_type, hard_limit_usd, soft_limit_usd, action_on_hard, action_on_soft, preset_source
+            SELECT id, scope_type, scope_id, window_type, hard_limit_micros, soft_limit_micros, action_on_hard, action_on_soft, preset_source
             FROM budgets
             WHERE window_type IN ('day', 'week', 'month', 'total')
               AND (
@@ -507,17 +508,21 @@ impl BudgetRepo for SqliteStore {
                     window_type = ?3,
                     hard_limit_usd = ?4,
                     soft_limit_usd = ?5,
-                    action_on_hard = ?6,
-                    action_on_soft = ?7,
-                    preset_source = ?8
-                WHERE id = ?9
+                    hard_limit_micros = ?6,
+                    soft_limit_micros = ?7,
+                    action_on_hard = ?8,
+                    action_on_soft = ?9,
+                    preset_source = ?10
+                WHERE id = ?11
                 "#,
             )
             .bind(scope_type_db)
             .bind(&budget.scope_id)
             .bind(window_type_db)
-            .bind(budget.hard_limit_usd)
-            .bind(budget.soft_limit_usd)
+            .bind(budget.hard_limit_usd.map(Money::to_usd))
+            .bind(budget.soft_limit_usd.map(Money::to_usd))
+            .bind(budget.hard_limit_usd.map(Money::micros))
+            .bind(budget.soft_limit_usd.map(Money::micros))
             .bind(&budget.action_on_hard)
             .bind(&budget.action_on_soft)
             .bind(&budget.preset_source)
@@ -550,14 +555,18 @@ impl BudgetRepo for SqliteStore {
                 UPDATE budgets
                 SET hard_limit_usd = ?1,
                     soft_limit_usd = ?2,
-                    action_on_hard = ?3,
-                    action_on_soft = ?4,
-                    preset_source = ?5
-                WHERE id = ?6
+                    hard_limit_micros = ?3,
+                    soft_limit_micros = ?4,
+                    action_on_hard = ?5,
+                    action_on_soft = ?6,
+                    preset_source = ?7
+                WHERE id = ?8
                 "#,
             )
-            .bind(budget.hard_limit_usd)
-            .bind(budget.soft_limit_usd)
+            .bind(budget.hard_limit_usd.map(Money::to_usd))
+            .bind(budget.soft_limit_usd.map(Money::to_usd))
+            .bind(budget.hard_limit_usd.map(Money::micros))
+            .bind(budget.soft_limit_usd.map(Money::micros))
             .bind(&budget.action_on_hard)
             .bind(&budget.action_on_soft)
             .bind(&budget.preset_source)
@@ -569,16 +578,18 @@ impl BudgetRepo for SqliteStore {
             sqlx::query(
                 r#"
                 INSERT INTO budgets (
-                    scope_type, scope_id, window_type, hard_limit_usd, soft_limit_usd, action_on_hard, action_on_soft, preset_source
+                    scope_type, scope_id, window_type, hard_limit_usd, soft_limit_usd, hard_limit_micros, soft_limit_micros, action_on_hard, action_on_soft, preset_source
                 )
-                VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)
+                VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)
                 "#,
             )
             .bind(scope_type_db)
             .bind(&budget.scope_id)
             .bind(window_type_db)
-            .bind(budget.hard_limit_usd)
-            .bind(budget.soft_limit_usd)
+            .bind(budget.hard_limit_usd.map(Money::to_usd))
+            .bind(budget.soft_limit_usd.map(Money::to_usd))
+            .bind(budget.hard_limit_usd.map(Money::micros))
+            .bind(budget.soft_limit_usd.map(Money::micros))
             .bind(&budget.action_on_hard)
             .bind(&budget.action_on_soft)
             .bind(&budget.preset_source)
@@ -597,7 +608,7 @@ impl BudgetRepo for SqliteStore {
     async fn list_all(&self) -> Result<Vec<Budget>, StoreError> {
         let rows = sqlx::query(
             r#"
-            SELECT id, scope_type, scope_id, window_type, hard_limit_usd, soft_limit_usd, action_on_hard, action_on_soft, preset_source
+            SELECT id, scope_type, scope_id, window_type, hard_limit_micros, soft_limit_micros, action_on_hard, action_on_soft, preset_source
             FROM budgets
             ORDER BY id
             "#,
@@ -884,8 +895,12 @@ fn budget_from_row(row: sqlx::sqlite::SqliteRow) -> Result<Budget, StoreError> {
         scope_type: scope_type_from_db(&scope_value)?,
         scope_id: row.get("scope_id"),
         window_type: window_type_from_db(&window_value)?,
-        hard_limit_usd: row.get("hard_limit_usd"),
-        soft_limit_usd: row.get("soft_limit_usd"),
+        hard_limit_usd: row
+            .get::<Option<i64>, _>("hard_limit_micros")
+            .map(Money::from_micros),
+        soft_limit_usd: row
+            .get::<Option<i64>, _>("soft_limit_micros")
+            .map(Money::from_micros),
         action_on_hard: row.get("action_on_hard"),
         action_on_soft: row.get("action_on_soft"),
         preset_source: row.get("preset_source"),
@@ -1032,7 +1047,7 @@ mod tests {
                 request_id,
                 input_tokens: 1234,
                 output_tokens: 321,
-                cost_usd: 0.42,
+                cost_usd: Money::from_usd(0.42).expect("money"),
                 source: UsageSource::Provider,
                 pricing_snapshot: json!({ "model": "claude-sonnet-4-6" }),
             })
@@ -1059,8 +1074,8 @@ mod tests {
             scope_type: ScopeType::Global,
             scope_id: "*".into(),
             window_type: WindowType::Day,
-            hard_limit_usd: Some(10.0),
-            soft_limit_usd: Some(8.0),
+            hard_limit_usd: Some(Money::from_usd(10.0).expect("money")),
+            soft_limit_usd: Some(Money::from_usd(8.0).expect("money")),
             action_on_hard: "block".into(),
             action_on_soft: "warn".into(),
             preset_source: None,
@@ -1070,7 +1085,7 @@ mod tests {
         assert!(stored.id > 0);
 
         let mut changed = stored.clone();
-        changed.hard_limit_usd = Some(12.5);
+        changed.hard_limit_usd = Some(Money::from_usd(12.5).expect("money"));
         store.upsert(&changed).await.expect("update budget");
 
         let applicable = store
@@ -1078,7 +1093,10 @@ mod tests {
             .await
             .expect("list applicable");
         assert_eq!(applicable.len(), 1);
-        assert_eq!(applicable[0].hard_limit_usd, Some(12.5));
+        assert_eq!(
+            applicable[0].hard_limit_usd,
+            Some(Money::from_usd(12.5).expect("money"))
+        );
 
         let all = store.list_all().await.expect("list all");
         assert_eq!(all.len(), 1);
@@ -1094,7 +1112,7 @@ mod tests {
                 scope_type: ScopeType::Global,
                 scope_id: "*".into(),
                 window_type: WindowType::Day,
-                hard_limit_usd: Some(100.0),
+                hard_limit_usd: Some(Money::from_usd(100.0).expect("money")),
                 soft_limit_usd: None,
                 action_on_hard: "block".into(),
                 action_on_soft: "warn".into(),
@@ -1105,7 +1123,7 @@ mod tests {
                 scope_type: ScopeType::Project,
                 scope_id: "project-alpha".into(),
                 window_type: WindowType::Week,
-                hard_limit_usd: Some(200.0),
+                hard_limit_usd: Some(Money::from_usd(200.0).expect("money")),
                 soft_limit_usd: None,
                 action_on_hard: "block".into(),
                 action_on_soft: "warn".into(),
@@ -1116,7 +1134,7 @@ mod tests {
                 scope_type: ScopeType::Session,
                 scope_id: "session-123".into(),
                 window_type: WindowType::Month,
-                hard_limit_usd: Some(300.0),
+                hard_limit_usd: Some(Money::from_usd(300.0).expect("money")),
                 soft_limit_usd: None,
                 action_on_hard: "block".into(),
                 action_on_soft: "warn".into(),
@@ -1127,7 +1145,7 @@ mod tests {
                 scope_type: ScopeType::Project,
                 scope_id: "other-project".into(),
                 window_type: WindowType::Total,
-                hard_limit_usd: Some(400.0),
+                hard_limit_usd: Some(Money::from_usd(400.0).expect("money")),
                 soft_limit_usd: None,
                 action_on_hard: "block".into(),
                 action_on_soft: "warn".into(),

--- a/crates/penny-types/src/lib.rs
+++ b/crates/penny-types/src/lib.rs
@@ -1,13 +1,205 @@
 //! Shared domain types for PennyPrompt.
 
 use chrono::{DateTime, Utc};
-use serde::{Deserialize, Serialize};
+use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
 use serde_json::Value;
+use std::{fmt, str::FromStr};
 use thiserror::Error;
 
 pub type RequestId = String;
 pub type SessionId = String;
 pub type ProjectId = String;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+pub struct Money(i64);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Error)]
+pub enum MoneyError {
+    #[error("money value must be finite")]
+    NonFinite,
+    #[error("money value is out of range")]
+    OutOfRange,
+    #[error("money decimal string is invalid")]
+    InvalidFormat,
+}
+
+impl Money {
+    pub const SCALE: i64 = 1_000_000;
+    pub const ZERO: Self = Self(0);
+
+    pub fn from_micros(micros: i64) -> Self {
+        Self(micros)
+    }
+
+    pub fn micros(self) -> i64 {
+        self.0
+    }
+
+    pub fn is_negative(self) -> bool {
+        self.0 < 0
+    }
+
+    pub fn checked_add(self, rhs: Self) -> Option<Self> {
+        self.0.checked_add(rhs.0).map(Self)
+    }
+
+    pub fn checked_sub(self, rhs: Self) -> Option<Self> {
+        self.0.checked_sub(rhs.0).map(Self)
+    }
+
+    pub fn from_usd(value: f64) -> Result<Self, MoneyError> {
+        if !value.is_finite() {
+            return Err(MoneyError::NonFinite);
+        }
+        let scaled = (value * Self::SCALE as f64).round();
+        if scaled < i64::MIN as f64 || scaled > i64::MAX as f64 {
+            return Err(MoneyError::OutOfRange);
+        }
+        Ok(Self(scaled as i64))
+    }
+
+    pub fn to_usd(self) -> f64 {
+        self.0 as f64 / Self::SCALE as f64
+    }
+}
+
+impl fmt::Display for Money {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let negative = self.0 < 0;
+        let abs = self.0.unsigned_abs();
+        let whole = abs / Money::SCALE as u64;
+        let frac = abs % Money::SCALE as u64;
+        if negative {
+            write!(f, "-{whole}.{frac:06}")
+        } else {
+            write!(f, "{whole}.{frac:06}")
+        }
+    }
+}
+
+impl Serialize for Money {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_f64(self.to_usd())
+    }
+}
+
+impl<'de> Deserialize<'de> for Money {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct MoneyVisitor;
+
+        impl<'de> de::Visitor<'de> for MoneyVisitor {
+            type Value = Money;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+                formatter.write_str("a decimal USD value as number or string")
+            }
+
+            fn visit_i64<E>(self, value: i64) -> Result<Self::Value, E>
+            where
+                E: de::Error,
+            {
+                Ok(Money::from_micros(
+                    value
+                        .checked_mul(Money::SCALE)
+                        .ok_or_else(|| E::custom(MoneyError::OutOfRange.to_string()))?,
+                ))
+            }
+
+            fn visit_u64<E>(self, value: u64) -> Result<Self::Value, E>
+            where
+                E: de::Error,
+            {
+                let signed = i64::try_from(value)
+                    .map_err(|_| E::custom(MoneyError::OutOfRange.to_string()))?;
+                self.visit_i64(signed)
+            }
+
+            fn visit_f64<E>(self, value: f64) -> Result<Self::Value, E>
+            where
+                E: de::Error,
+            {
+                Money::from_usd(value).map_err(|err| E::custom(err.to_string()))
+            }
+
+            fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
+            where
+                E: de::Error,
+            {
+                parse_money_str(value).map_err(|err| E::custom(err.to_string()))
+            }
+        }
+
+        deserializer.deserialize_any(MoneyVisitor)
+    }
+}
+
+impl FromStr for Money {
+    type Err = MoneyError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        parse_money_str(s)
+    }
+}
+
+fn parse_money_str(value: &str) -> Result<Money, MoneyError> {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        return Err(MoneyError::InvalidFormat);
+    }
+
+    let (negative, digits) = match trimmed.as_bytes()[0] {
+        b'-' => (true, &trimmed[1..]),
+        b'+' => (false, &trimmed[1..]),
+        _ => (false, trimmed),
+    };
+
+    if digits.is_empty() {
+        return Err(MoneyError::InvalidFormat);
+    }
+
+    let mut parts = digits.split('.');
+    let whole_part = parts.next().ok_or(MoneyError::InvalidFormat)?;
+    let frac_part = parts.next();
+    if parts.next().is_some() {
+        return Err(MoneyError::InvalidFormat);
+    }
+
+    let whole: i64 = whole_part.parse().map_err(|_| MoneyError::InvalidFormat)?;
+    let frac = match frac_part {
+        None => 0_i64,
+        Some(raw) => {
+            if raw.is_empty() || raw.len() > 6 || !raw.chars().all(|ch| ch.is_ascii_digit()) {
+                return Err(MoneyError::InvalidFormat);
+            }
+            let mut padded = raw.to_string();
+            while padded.len() < 6 {
+                padded.push('0');
+            }
+            padded
+                .parse::<i64>()
+                .map_err(|_| MoneyError::InvalidFormat)?
+        }
+    };
+
+    let whole_scaled = whole
+        .checked_mul(Money::SCALE)
+        .ok_or(MoneyError::OutOfRange)?;
+    let mut micros = whole_scaled
+        .checked_add(frac)
+        .ok_or(MoneyError::OutOfRange)?;
+
+    if negative {
+        micros = micros.checked_neg().ok_or(MoneyError::OutOfRange)?;
+    }
+
+    Ok(Money::from_micros(micros))
+}
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct NormalizedRequest {
@@ -48,7 +240,7 @@ pub struct StreamDescriptor {
 pub struct AccountedUsage {
     pub input_tokens: u64,
     pub output_tokens: u64,
-    pub cost_usd: f64,
+    pub cost_usd: Money,
     pub source: UsageSource,
     pub pricing_snapshot: Value,
 }
@@ -67,8 +259,8 @@ pub struct Budget {
     pub scope_type: ScopeType,
     pub scope_id: String,
     pub window_type: WindowType,
-    pub hard_limit_usd: Option<f64>,
-    pub soft_limit_usd: Option<f64>,
+    pub hard_limit_usd: Option<Money>,
+    pub soft_limit_usd: Option<Money>,
     pub action_on_hard: String,
     pub action_on_soft: String,
     pub preset_source: Option<String>,
@@ -111,8 +303,8 @@ pub enum RouteDecision {
 pub struct BudgetBlockDetail {
     pub scope: String,
     pub window: WindowType,
-    pub accumulated_usd: f64,
-    pub limit_usd: f64,
+    pub accumulated_usd: Money,
+    pub limit_usd: Money,
     pub resets_at: Option<DateTime<Utc>>,
 }
 
@@ -129,8 +321,8 @@ pub struct LedgerEntry {
     pub request_id: RequestId,
     pub entry_type: LedgerEntryType,
     pub budget_id: i64,
-    pub amount_usd: f64,
-    pub running_total: f64,
+    pub amount_usd: Money,
+    pub running_total: Money,
     pub created_at: DateTime<Utc>,
 }
 
@@ -151,8 +343,8 @@ pub enum Reservation {
     },
     Denied {
         budget: Budget,
-        accumulated: f64,
-        limit: f64,
+        accumulated: Money,
+        limit: Money,
         reason: String,
     },
 }
@@ -160,14 +352,14 @@ pub enum Reservation {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct BudgetRemaining {
     pub budget_id: i64,
-    pub remaining_usd: f64,
+    pub remaining_usd: Option<Money>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct RequestDigest {
     pub model: String,
     pub input_tokens: u64,
-    pub cost_usd: f64,
+    pub cost_usd: Money,
     pub tool_name: Option<String>,
     pub tool_succeeded: bool,
     pub content_hash: u64,
@@ -349,8 +541,8 @@ mod tests {
             scope_type: ScopeType::Global,
             scope_id: "*".into(),
             window_type: WindowType::Day,
-            hard_limit_usd: Some(10.0),
-            soft_limit_usd: Some(8.0),
+            hard_limit_usd: Some(Money::from_usd(10.0).expect("money")),
+            soft_limit_usd: Some(Money::from_usd(8.0).expect("money")),
             action_on_hard: "block".into(),
             action_on_soft: "warn".into(),
             preset_source: Some("preset:indie".into()),
@@ -362,8 +554,8 @@ mod tests {
             detail: BudgetBlockDetail {
                 scope: "global:*".into(),
                 window: WindowType::Day,
-                accumulated_usd: 10.12,
-                limit_usd: 10.0,
+                accumulated_usd: Money::from_usd(10.12).expect("money"),
+                limit_usd: Money::from_usd(10.0).expect("money"),
                 resets_at: Some(ts()),
             },
         };
@@ -377,8 +569,8 @@ mod tests {
             request_id: "req_01".into(),
             entry_type: LedgerEntryType::Reserve,
             budget_id: 10,
-            amount_usd: 0.25,
-            running_total: 1.75,
+            amount_usd: Money::from_usd(0.25).expect("money"),
+            running_total: Money::from_usd(1.75).expect("money"),
             created_at: ts(),
         };
         assert_round_trip(&entry);
@@ -387,7 +579,7 @@ mod tests {
             entries: vec![1, 2],
             remaining_by_budget: vec![BudgetRemaining {
                 budget_id: 10,
-                remaining_usd: 8.25,
+                remaining_usd: Some(Money::from_usd(8.25).expect("money")),
             }],
         };
         assert_round_trip(&reservation);
@@ -398,7 +590,7 @@ mod tests {
         let digest = RequestDigest {
             model: "claude-sonnet-4-6".into(),
             input_tokens: 2000,
-            cost_usd: 0.43,
+            cost_usd: Money::from_usd(0.43).expect("money"),
             tool_name: Some("shell".into()),
             tool_succeeded: false,
             content_hash: 998877,
@@ -435,5 +627,15 @@ mod tests {
 
         let error = PennyError::Budget("hard limit exceeded".into());
         assert_round_trip(&error);
+    }
+
+    #[test]
+    fn money_round_trip_and_parse() {
+        let value = Money::from_usd(12.345678).expect("money");
+        assert_eq!(value.to_string(), "12.345678");
+        assert_round_trip(&value);
+
+        let parsed = "0.42".parse::<Money>().expect("parse money");
+        assert_eq!(parsed, Money::from_usd(0.42).expect("money"));
     }
 }

--- a/docs/money-migration-2026-04.md
+++ b/docs/money-migration-2026-04.md
@@ -1,0 +1,24 @@
+# Money Hardening Migration Notes (Issue #45)
+
+## What changed
+- Introduced deterministic `Money` type in `penny-types` using integer micro-USD precision (`1 USD = 1_000_000 micros`).
+- Accounting-critical structs now use `Money` instead of `f64`:
+  - budgets (`hard_limit_usd`, `soft_limit_usd`)
+  - ledger entries (`amount_usd`, `running_total`)
+  - reservation/block details (`accumulated_usd`, `limit_usd`, `remaining_usd`)
+  - accounted usage (`cost_usd`)
+- Budget/ledger math now uses exact integer arithmetic.
+
+## Database compatibility strategy
+- Added migration `0008_money_micros.sql`.
+- New deterministic columns were introduced and backfilled from legacy `REAL` columns:
+  - `budgets.hard_limit_micros`, `budgets.soft_limit_micros`
+  - `request_usage.cost_micros`
+  - `cost_ledger.amount_micros`, `cost_ledger.running_total_micros`
+- Existing `REAL` columns remain during transition for compatibility and diagnostics.
+- Repositories now read/write the `*_micros` columns for accounting logic, and still dual-write legacy `REAL` columns where relevant.
+
+## Operational notes
+- Existing databases are migrated in-place via SQLx migration runner at startup.
+- New environments receive all migrations, including `0008`, automatically.
+- For forensic checks, `*_micros` values are now the source of truth.

--- a/migrations/0008_money_micros.sql
+++ b/migrations/0008_money_micros.sql
@@ -1,0 +1,29 @@
+-- Introduce deterministic integer money columns (micro-USD) while keeping
+-- legacy REAL columns for compatibility during rollout.
+
+ALTER TABLE budgets ADD COLUMN hard_limit_micros INTEGER;
+ALTER TABLE budgets ADD COLUMN soft_limit_micros INTEGER;
+
+UPDATE budgets
+SET
+    hard_limit_micros = CASE
+        WHEN hard_limit_usd IS NULL THEN NULL
+        ELSE CAST(ROUND(hard_limit_usd * 1000000.0) AS INTEGER)
+    END,
+    soft_limit_micros = CASE
+        WHEN soft_limit_usd IS NULL THEN NULL
+        ELSE CAST(ROUND(soft_limit_usd * 1000000.0) AS INTEGER)
+    END;
+
+ALTER TABLE request_usage ADD COLUMN cost_micros INTEGER NOT NULL DEFAULT 0;
+
+UPDATE request_usage
+SET cost_micros = CAST(ROUND(cost_usd * 1000000.0) AS INTEGER);
+
+ALTER TABLE cost_ledger ADD COLUMN amount_micros INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE cost_ledger ADD COLUMN running_total_micros INTEGER NOT NULL DEFAULT 0;
+
+UPDATE cost_ledger
+SET
+    amount_micros = CAST(ROUND(amount_usd * 1000000.0) AS INTEGER),
+    running_total_micros = CAST(ROUND(running_total * 1000000.0) AS INTEGER);


### PR DESCRIPTION
## Summary
Implements issue #45 by replacing accounting-critical `f64` usage with a deterministic `Money` type (micro-USD) across M3 paths.

### What changed
- Added `Money` type in `penny-types` with fixed micro-USD precision and serde support.
- Migrated accounting domain fields (`Budget`, `LedgerEntry`, reservation/block details, usage cost) to `Money`.
- Added DB migration `0008_money_micros.sql` with backfill:
  - `budgets.hard_limit_micros`, `budgets.soft_limit_micros`
  - `request_usage.cost_micros`
  - `cost_ledger.amount_micros`, `cost_ledger.running_total_micros`
- Updated `penny-store` repos to read/write `*_micros` as source of truth (with compatibility dual-write to legacy REAL fields).
- Refactored `penny-ledger` and `penny-budget` arithmetic/comparisons to exact integer math.
- Updated `penny-cost` pricing calculation to output deterministic `Money`.
- Updated `penny-proxy` budget/cost/reconcile flow to use `Money` at internal boundaries.
- Added migration/compatibility note in `docs/money-migration-2026-04.md`.

## Why now
This is a blocker hardening task before scaling M3/M4 enforcement and streaming reconciliation behavior.

## Validation
- cargo check --workspace
- cargo test -p penny-types -p penny-store -p penny-ledger -p penny-budget -p penny-cost -p penny-proxy

Closes #45
