### PR TITLE
feat(providers): implement Anthropic adapter with non-stream/stream translation (#22)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -263,6 +263,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
 name = "chrono"
 version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -659,8 +665,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "libc",
+ "r-efi 5.3.0",
+ "wasip2",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -671,7 +693,7 @@ checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 6.0.0",
  "wasip2",
  "wasip3",
 ]
@@ -804,6 +826,23 @@ dependencies = [
  "pin-project-lite",
  "smallvec",
  "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+ "webpki-roots 1.0.6",
 ]
 
 [[package]]
@@ -812,13 +851,21 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
+ "base64 0.22.1",
  "bytes",
+ "futures-channel",
+ "futures-util",
  "http",
  "http-body",
  "hyper",
+ "ipnet",
+ "libc",
+ "percent-encoding",
  "pin-project-lite",
+ "socket2",
  "tokio",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -967,6 +1014,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "ipnet"
+version = "2.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+
+[[package]]
+name = "iri-string"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25e659a4bb38e810ebc252e53b5814ff908a8c58c2a9ce2fae1bbec24cbf4e20"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -984,6 +1047,8 @@ version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
 dependencies = [
+ "cfg-if",
+ "futures-util",
  "once_cell",
  "wasm-bindgen",
 ]
@@ -1072,6 +1137,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
 name = "matchit"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1121,7 +1192,7 @@ dependencies = [
  "num-integer",
  "num-iter",
  "num-traits",
- "rand",
+ "rand 0.8.5",
  "smallvec",
  "zeroize",
 ]
@@ -1292,6 +1363,7 @@ dependencies = [
  "async-trait",
  "chrono",
  "penny-types",
+ "reqwest",
  "serde_json",
  "thiserror 1.0.69",
  "tokio",
@@ -1427,6 +1499,61 @@ dependencies = [
 ]
 
 [[package]]
+name = "quinn"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash 2.1.2",
+ "rustls",
+ "socket2",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+dependencies = [
+ "bytes",
+ "getrandom 0.3.4",
+ "lru-slab",
+ "rand 0.9.4",
+ "ring",
+ "rustc-hash 2.1.2",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1434,6 +1561,12 @@ checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "r-efi"
@@ -1448,8 +1581,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -1459,7 +1602,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -1469,6 +1622,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.17",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
 ]
 
 [[package]]
@@ -1519,6 +1681,44 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
+name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "webpki-roots 1.0.6",
+]
+
+[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1545,7 +1745,7 @@ dependencies = [
  "num-traits",
  "pkcs1",
  "pkcs8",
- "rand_core",
+ "rand_core 0.6.4",
  "signature",
  "spki",
  "subtle",
@@ -1557,6 +1757,12 @@ name = "rustc-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
+name = "rustc-hash"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
 name = "rustix"
@@ -1591,6 +1797,7 @@ version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
 dependencies = [
+ "web-time",
  "zeroize",
 ]
 
@@ -1739,7 +1946,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
  "digest",
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -1905,7 +2112,7 @@ dependencies = [
  "memchr",
  "once_cell",
  "percent-encoding",
- "rand",
+ "rand 0.8.5",
  "rsa",
  "serde",
  "sha1",
@@ -1945,7 +2152,7 @@ dependencies = [
  "md-5",
  "memchr",
  "once_cell",
- "rand",
+ "rand 0.8.5",
  "serde",
  "serde_json",
  "sha2",
@@ -2029,6 +2236,9 @@ name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
+]
 
 [[package]]
 name = "synstructure"
@@ -2107,7 +2317,7 @@ dependencies = [
  "lazy_static",
  "parking_lot",
  "regex",
- "rustc-hash",
+ "rustc-hash 1.1.0",
 ]
 
 [[package]]
@@ -2159,6 +2369,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
 ]
 
 [[package]]
@@ -2230,6 +2450,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "tower-http"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
+dependencies = [
+ "bitflags",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "iri-string",
+ "pin-project-lite",
+ "tower",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
 name = "tower-layer"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2272,6 +2510,12 @@ checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
 ]
+
+[[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "typenum"
@@ -2379,6 +2623,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
+]
+
+[[package]]
 name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2419,6 +2672,16 @@ dependencies = [
  "rustversion",
  "wasm-bindgen-macro",
  "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.68"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f371d383f2fb139252e0bfac3b81b265689bf45b6874af544ffa4c975ac1ebf8"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -2485,6 +2748,26 @@ dependencies = [
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.95"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f2dfbb17949fa2088e5d39408c48368947b86f7834484e87b73de55bc14d97d"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]

--- a/crates/penny-providers/Cargo.toml
+++ b/crates/penny-providers/Cargo.toml
@@ -7,6 +7,7 @@ publish = false
 [dependencies]
 async-trait = "0.1"
 penny-types = { path = "../penny-types" }
+reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 serde_json = "1"
 thiserror = "1"
 

--- a/crates/penny-providers/src/lib.rs
+++ b/crates/penny-providers/src/lib.rs
@@ -2,13 +2,20 @@
 
 use async_trait::async_trait;
 use penny_types::{NormalizedRequest, ProviderResponse, ResponseBody, StreamDescriptor};
+use reqwest::{header::CONTENT_TYPE, Client, StatusCode};
 use serde_json::{json, Value};
+use std::{
+    collections::HashMap,
+    sync::{Mutex, MutexGuard},
+};
 use thiserror::Error;
 
 #[derive(Debug, Error)]
 pub enum ProviderError {
     #[error("model `{0}` is not supported by provider")]
     UnsupportedModel(String),
+    #[error("provider internal state is unavailable: {0}")]
+    InternalState(String),
 }
 
 #[async_trait]
@@ -18,6 +25,287 @@ pub trait ProviderAdapter: Send + Sync {
     fn supports_model(&self, model: &str) -> bool;
     fn stream_response_lines(&self, _req: &NormalizedRequest) -> Option<Vec<String>> {
         None
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct AnthropicProviderConfig {
+    pub provider_id: String,
+    pub base_url: String,
+    pub api_key: String,
+    pub api_version: String,
+    pub supported_models: Vec<String>,
+    pub timeout_ms: u64,
+}
+
+impl Default for AnthropicProviderConfig {
+    fn default() -> Self {
+        Self {
+            provider_id: "anthropic".to_string(),
+            base_url: "https://api.anthropic.com".to_string(),
+            api_key: String::new(),
+            api_version: "2023-06-01".to_string(),
+            supported_models: vec!["claude-sonnet-4-6".to_string()],
+            timeout_ms: 60_000,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct AnthropicProvider {
+    config: AnthropicProviderConfig,
+    client: Client,
+    pending_streams: ArcStreamCache,
+}
+
+type ArcStreamCache = std::sync::Arc<Mutex<HashMap<String, Vec<String>>>>;
+
+#[derive(Debug, Default)]
+struct AnthropicStreamState {
+    message_id: Option<String>,
+    model: Option<String>,
+    input_tokens: Option<u64>,
+    output_tokens: Option<u64>,
+    finish_reason: Option<String>,
+    deltas: Vec<String>,
+}
+
+impl AnthropicProvider {
+    pub fn new(config: AnthropicProviderConfig) -> Result<Self, String> {
+        let timeout = std::time::Duration::from_millis(config.timeout_ms.max(1));
+        let client = Client::builder()
+            .timeout(timeout)
+            .build()
+            .map_err(|err| err.to_string())?;
+        Ok(Self {
+            config,
+            client,
+            pending_streams: std::sync::Arc::new(Mutex::new(HashMap::new())),
+        })
+    }
+
+    fn endpoint_url(&self) -> String {
+        format!("{}/v1/messages", self.config.base_url.trim_end_matches('/'))
+    }
+
+    fn anthropic_headers(&self, request: reqwest::RequestBuilder) -> reqwest::RequestBuilder {
+        request
+            .header("x-api-key", &self.config.api_key)
+            .header("anthropic-version", &self.config.api_version)
+            .header(CONTENT_TYPE, "application/json")
+    }
+
+    fn build_payload(&self, req: &NormalizedRequest) -> Value {
+        let mut system_segments: Vec<String> = Vec::new();
+        let mut anthropic_messages: Vec<Value> = Vec::new();
+        if let Some(messages) = req.messages.as_array() {
+            for message in messages {
+                let role = message
+                    .get("role")
+                    .and_then(Value::as_str)
+                    .unwrap_or("user");
+                let text = extract_message_text(message.get("content").unwrap_or(&Value::Null))
+                    .unwrap_or_default();
+                if text.is_empty() {
+                    continue;
+                }
+                if role == "system" {
+                    system_segments.push(text);
+                    continue;
+                }
+                let normalized_role = match role {
+                    "assistant" => "assistant",
+                    _ => "user",
+                };
+                anthropic_messages.push(json!({
+                    "role": normalized_role,
+                    "content": [{"type": "text", "text": text}],
+                }));
+            }
+        }
+
+        let mut payload = json!({
+            "model": req.model_resolved,
+            "messages": anthropic_messages,
+            "max_tokens": req.estimated_output_tokens.max(1),
+            "stream": req.stream,
+        });
+        if !system_segments.is_empty() {
+            payload["system"] = Value::String(system_segments.join("\n"));
+        }
+        payload
+    }
+
+    fn map_non_stream_response(&self, req: &NormalizedRequest, payload: &Value) -> Value {
+        let message_id = payload
+            .get("id")
+            .and_then(Value::as_str)
+            .map(ToOwned::to_owned)
+            .unwrap_or_else(|| format!("msg_{}", req.id));
+        let model = payload
+            .get("model")
+            .and_then(Value::as_str)
+            .unwrap_or(&req.model_resolved)
+            .to_string();
+        let content = payload
+            .get("content")
+            .and_then(Value::as_array)
+            .map(|blocks| {
+                blocks
+                    .iter()
+                    .filter_map(|block| block.get("text").and_then(Value::as_str))
+                    .collect::<Vec<_>>()
+                    .join("")
+            })
+            .unwrap_or_default();
+        let usage = payload.get("usage").cloned().unwrap_or_else(|| json!({}));
+        let prompt_tokens = usage
+            .get("input_tokens")
+            .and_then(Value::as_u64)
+            .unwrap_or(0);
+        let completion_tokens = usage
+            .get("output_tokens")
+            .and_then(Value::as_u64)
+            .unwrap_or(0);
+        let finish_reason = map_finish_reason(
+            payload
+                .get("stop_reason")
+                .and_then(Value::as_str)
+                .unwrap_or("end_turn"),
+        );
+
+        json!({
+            "id": message_id,
+            "object": "chat.completion",
+            "created": req.timestamp.timestamp(),
+            "model": model,
+            "choices": [{
+                "index": 0,
+                "message": {
+                    "role": "assistant",
+                    "content": content,
+                },
+                "finish_reason": finish_reason,
+            }],
+            "usage": {
+                "prompt_tokens": prompt_tokens,
+                "completion_tokens": completion_tokens,
+                "total_tokens": prompt_tokens + completion_tokens,
+            },
+        })
+    }
+
+    fn map_error_response(&self, status: StatusCode, body: &str) -> Value {
+        let parsed: Option<Value> = serde_json::from_str(body).ok();
+        let message = parsed
+            .as_ref()
+            .and_then(|json| json.get("error"))
+            .and_then(|error| error.get("message"))
+            .and_then(Value::as_str)
+            .unwrap_or(body)
+            .trim()
+            .to_string();
+        let error_type = parsed
+            .as_ref()
+            .and_then(|json| json.get("error"))
+            .and_then(|error| error.get("type"))
+            .and_then(Value::as_str)
+            .unwrap_or("provider_error")
+            .to_string();
+        json!({
+            "error": {
+                "message": if message.is_empty() { format!("upstream request failed with status {}", status.as_u16()) } else { message },
+                "type": error_type,
+                "code": status.as_u16(),
+            }
+        })
+    }
+
+    fn map_stream_lines(&self, req: &NormalizedRequest, raw_body: &str) -> Vec<String> {
+        let mut state = AnthropicStreamState::default();
+        for block in split_sse_blocks(raw_body) {
+            let event = parse_sse_event(block);
+            if event.data.eq_ignore_ascii_case("[done]") {
+                continue;
+            }
+            let parsed: Value = match serde_json::from_str(&event.data) {
+                Ok(value) => value,
+                Err(_) => continue,
+            };
+            match event.name.as_deref() {
+                Some("message_start") => {
+                    let message = parsed.get("message").unwrap_or(&Value::Null);
+                    state.message_id = message
+                        .get("id")
+                        .and_then(Value::as_str)
+                        .map(ToOwned::to_owned);
+                    state.model = message
+                        .get("model")
+                        .and_then(Value::as_str)
+                        .map(ToOwned::to_owned);
+                    state.input_tokens = message
+                        .get("usage")
+                        .and_then(|usage| usage.get("input_tokens"))
+                        .and_then(Value::as_u64)
+                        .or(state.input_tokens);
+                    state.output_tokens = message
+                        .get("usage")
+                        .and_then(|usage| usage.get("output_tokens"))
+                        .and_then(Value::as_u64)
+                        .or(state.output_tokens);
+                }
+                Some("content_block_start") => {
+                    if let Some(text) = parsed
+                        .get("content_block")
+                        .and_then(|block| block.get("text"))
+                        .and_then(Value::as_str)
+                    {
+                        if !text.is_empty() {
+                            state.deltas.push(text.to_string());
+                        }
+                    }
+                }
+                Some("content_block_delta") => {
+                    if let Some(text) = parsed
+                        .get("delta")
+                        .and_then(|delta| delta.get("text"))
+                        .and_then(Value::as_str)
+                    {
+                        if !text.is_empty() {
+                            state.deltas.push(text.to_string());
+                        }
+                    }
+                }
+                Some("message_delta") => {
+                    state.output_tokens = parsed
+                        .get("usage")
+                        .and_then(|usage| usage.get("output_tokens"))
+                        .and_then(Value::as_u64)
+                        .or(state.output_tokens);
+                    state.finish_reason = parsed
+                        .get("delta")
+                        .and_then(|delta| delta.get("stop_reason"))
+                        .and_then(Value::as_str)
+                        .map(ToOwned::to_owned)
+                        .or(state.finish_reason);
+                }
+                Some("message_stop") => {
+                    state.finish_reason = state
+                        .finish_reason
+                        .take()
+                        .or_else(|| Some("end_turn".to_string()));
+                }
+                _ => {}
+            }
+        }
+
+        build_openai_sse_lines(req, &state)
+    }
+
+    fn lock_streams(&self) -> Result<MutexGuard<'_, HashMap<String, Vec<String>>>, ProviderError> {
+        self.pending_streams
+            .lock()
+            .map_err(|err| ProviderError::InternalState(err.to_string()))
     }
 }
 
@@ -181,11 +469,208 @@ impl ProviderAdapter for MockProvider {
     }
 }
 
+#[async_trait]
+impl ProviderAdapter for AnthropicProvider {
+    async fn send(&self, req: NormalizedRequest) -> Result<ProviderResponse, ProviderError> {
+        if !self.supports_model(&req.model_resolved) && !self.supports_model(&req.model_requested) {
+            return Err(ProviderError::UnsupportedModel(req.model_requested));
+        }
+
+        let payload = self.build_payload(&req);
+        let request = self.client.post(self.endpoint_url()).json(&payload);
+        let request = self.anthropic_headers(request);
+        let response = match request.send().await {
+            Ok(response) => response,
+            Err(error) => {
+                return Ok(ProviderResponse {
+                    status: StatusCode::BAD_GATEWAY.as_u16(),
+                    body: ResponseBody::Complete(json!({
+                        "error": {
+                            "message": error.to_string(),
+                            "type": "upstream_unavailable",
+                            "code": StatusCode::BAD_GATEWAY.as_u16(),
+                        }
+                    })),
+                    upstream_ms: 0,
+                });
+            }
+        };
+        let status = response.status();
+        let body_text = response.text().await.unwrap_or_default();
+
+        if !status.is_success() {
+            return Ok(ProviderResponse {
+                status: status.as_u16(),
+                body: ResponseBody::Complete(self.map_error_response(status, &body_text)),
+                upstream_ms: 0,
+            });
+        }
+
+        if req.stream {
+            let lines = self.map_stream_lines(&req, &body_text);
+            let mut streams = self.lock_streams()?;
+            streams.insert(req.id.clone(), lines);
+            return Ok(ProviderResponse {
+                status: status.as_u16(),
+                body: ResponseBody::Stream(StreamDescriptor {
+                    provider: self.provider_id().to_string(),
+                    format: "sse".to_string(),
+                }),
+                upstream_ms: 0,
+            });
+        }
+
+        let parsed: Value = serde_json::from_str(&body_text).unwrap_or_else(|_| json!({}));
+        Ok(ProviderResponse {
+            status: status.as_u16(),
+            body: ResponseBody::Complete(self.map_non_stream_response(&req, &parsed)),
+            upstream_ms: 0,
+        })
+    }
+
+    fn provider_id(&self) -> &str {
+        &self.config.provider_id
+    }
+
+    fn supports_model(&self, model: &str) -> bool {
+        if self.config.supported_models.iter().any(|m| m == model) {
+            return true;
+        }
+        model.starts_with("claude")
+    }
+
+    fn stream_response_lines(&self, req: &NormalizedRequest) -> Option<Vec<String>> {
+        let mut streams = self.lock_streams().ok()?;
+        streams.remove(&req.id)
+    }
+}
+
+#[derive(Debug, Default)]
+struct SseEvent {
+    name: Option<String>,
+    data: String,
+}
+
+fn split_sse_blocks(raw_body: &str) -> Vec<&str> {
+    raw_body
+        .split("\n\n")
+        .filter(|chunk| !chunk.trim().is_empty())
+        .collect()
+}
+
+fn parse_sse_event(raw_event: &str) -> SseEvent {
+    let mut event = SseEvent::default();
+    let mut data_lines = Vec::new();
+    for line in raw_event.lines() {
+        if let Some(name) = line.strip_prefix("event:") {
+            event.name = Some(name.trim().to_string());
+            continue;
+        }
+        if let Some(data) = line.strip_prefix("data:") {
+            data_lines.push(data.trim().to_string());
+        }
+    }
+    event.data = data_lines.join("\n");
+    event
+}
+
+fn build_openai_sse_lines(req: &NormalizedRequest, state: &AnthropicStreamState) -> Vec<String> {
+    let message_id = state.message_id.as_deref().unwrap_or(&req.id).to_string();
+    let model = state
+        .model
+        .as_deref()
+        .unwrap_or(&req.model_resolved)
+        .to_string();
+    let finish_reason = map_finish_reason(state.finish_reason.as_deref().unwrap_or("end_turn"));
+    let prompt_tokens = state.input_tokens.unwrap_or(0);
+    let completion_tokens = state.output_tokens.unwrap_or(0);
+
+    let mut lines = Vec::with_capacity(state.deltas.len() + 3);
+    let first_chunk = json!({
+        "id": message_id,
+        "object": "chat.completion.chunk",
+        "created": req.timestamp.timestamp(),
+        "model": model,
+        "choices": [{
+            "index": 0,
+            "delta": {"role": "assistant"},
+            "finish_reason": Value::Null,
+        }],
+    });
+    lines.push(format!("data: {first_chunk}\n\n"));
+
+    for delta in &state.deltas {
+        let chunk = json!({
+            "id": message_id,
+            "object": "chat.completion.chunk",
+            "created": req.timestamp.timestamp(),
+            "model": model,
+            "choices": [{
+                "index": 0,
+                "delta": {"content": delta},
+                "finish_reason": Value::Null,
+            }],
+        });
+        lines.push(format!("data: {chunk}\n\n"));
+    }
+
+    let final_chunk = json!({
+        "id": message_id,
+        "object": "chat.completion.chunk",
+        "created": req.timestamp.timestamp(),
+        "model": model,
+        "choices": [{
+            "index": 0,
+            "delta": {},
+            "finish_reason": finish_reason,
+        }],
+        "usage": {
+            "prompt_tokens": prompt_tokens,
+            "completion_tokens": completion_tokens,
+            "total_tokens": prompt_tokens + completion_tokens,
+        }
+    });
+    lines.push(format!("data: {final_chunk}\n\n"));
+    lines.push("data: [DONE]\n\n".to_string());
+    lines
+}
+
+fn extract_message_text(content: &Value) -> Option<String> {
+    if let Some(text) = content.as_str() {
+        return Some(text.to_string());
+    }
+    let blocks = content.as_array()?;
+    let joined = blocks
+        .iter()
+        .filter_map(|entry| {
+            if let Some(text) = entry.get("text").and_then(Value::as_str) {
+                return Some(text.to_string());
+            }
+            entry.as_str().map(ToOwned::to_owned)
+        })
+        .collect::<Vec<_>>()
+        .join("");
+    Some(joined)
+}
+
+fn map_finish_reason(reason: &str) -> &'static str {
+    match reason {
+        "max_tokens" => "length",
+        "tool_use" => "tool_calls",
+        _ => "stop",
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use chrono::{TimeZone, Utc};
     use penny_types::ResponseBody;
+    use tokio::{
+        io::{AsyncReadExt, AsyncWriteExt},
+        net::TcpListener,
+        sync::oneshot,
+    };
 
     fn request(stream: bool) -> NormalizedRequest {
         NormalizedRequest {
@@ -279,8 +764,177 @@ mod tests {
         req.model_resolved = "unknown-model".to_string();
 
         let err = provider.send(req).await.expect_err("should fail");
-        match err {
-            ProviderError::UnsupportedModel(model) => assert_eq!(model, "unknown-model"),
+        assert!(matches!(err, ProviderError::UnsupportedModel(model) if model == "unknown-model"));
+    }
+
+    fn anthropic_provider(base_url: String) -> AnthropicProvider {
+        AnthropicProvider::new(AnthropicProviderConfig {
+            base_url,
+            api_key: "test-key".to_string(),
+            supported_models: vec!["claude-sonnet-4-6".to_string()],
+            ..AnthropicProviderConfig::default()
+        })
+        .expect("provider should build")
+    }
+
+    async fn spawn_single_response_server(
+        status: u16,
+        content_type: &'static str,
+        response_body: String,
+    ) -> (String, oneshot::Receiver<String>) {
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind test server");
+        let addr = listener.local_addr().expect("local addr");
+        let (tx, rx) = oneshot::channel();
+        tokio::spawn(async move {
+            let (mut stream, _) = listener.accept().await.expect("accept request");
+            let mut buffer = vec![0_u8; 64 * 1024];
+            let read = stream.read(&mut buffer).await.expect("read request");
+            let request_raw = String::from_utf8_lossy(&buffer[..read]).to_string();
+            let _ = tx.send(request_raw);
+
+            let reason = match status {
+                200 => "OK",
+                401 => "Unauthorized",
+                502 => "Bad Gateway",
+                _ => "OK",
+            };
+            let response = format!(
+                "HTTP/1.1 {status} {reason}\r\nContent-Type: {content_type}\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{response_body}",
+                response_body.len()
+            );
+            stream
+                .write_all(response.as_bytes())
+                .await
+                .expect("write response");
+        });
+        (format!("http://{addr}"), rx)
+    }
+
+    #[tokio::test]
+    async fn anthropic_non_stream_is_mapped_to_openai_shape() {
+        let (base_url, request_rx) = spawn_single_response_server(
+            200,
+            "application/json",
+            json!({
+                "id": "msg_abc",
+                "model": "claude-sonnet-4-6",
+                "stop_reason": "end_turn",
+                "content": [{"type": "text", "text": "Hello from Anthropic"}],
+                "usage": {"input_tokens": 42, "output_tokens": 11}
+            })
+            .to_string(),
+        )
+        .await;
+
+        let provider = anthropic_provider(base_url);
+        let mut req = request(false);
+        req.provider_id = "anthropic".to_string();
+
+        let response = provider.send(req).await.expect("response");
+        assert_eq!(response.status, 200);
+        let request_raw = request_rx.await.expect("captured request").to_lowercase();
+        assert!(request_raw.starts_with("post /v1/messages"));
+        assert!(request_raw.contains("x-api-key: test-key"));
+        assert!(request_raw.contains("anthropic-version: 2023-06-01"));
+        match response.body {
+            ResponseBody::Complete(payload) => {
+                assert_eq!(payload["object"], "chat.completion");
+                assert_eq!(
+                    payload["choices"][0]["message"]["content"],
+                    "Hello from Anthropic"
+                );
+                assert_eq!(payload["usage"]["prompt_tokens"], 42);
+                assert_eq!(payload["usage"]["completion_tokens"], 11);
+            }
+            other => panic!("expected complete response, got {other:?}"),
         }
+    }
+
+    #[tokio::test]
+    async fn anthropic_streaming_sse_is_rewritten_with_usage_chunk() {
+        let sse = [
+            "event: message_start\n",
+            "data: {\"message\":{\"id\":\"msg_stream\",\"model\":\"claude-sonnet-4-6\",\"usage\":{\"input_tokens\":33,\"output_tokens\":0}}}\n\n",
+            "event: content_block_delta\n",
+            "data: {\"delta\":{\"text\":\"Hello\"}}\n\n",
+            "event: content_block_delta\n",
+            "data: {\"delta\":{\"text\":\" world\"}}\n\n",
+            "event: message_delta\n",
+            "data: {\"delta\":{\"stop_reason\":\"end_turn\"},\"usage\":{\"output_tokens\":9}}\n\n",
+            "event: message_stop\n",
+            "data: {}\n\n",
+        ]
+        .concat();
+        let (base_url, _) = spawn_single_response_server(200, "text/event-stream", sse).await;
+
+        let provider = anthropic_provider(base_url);
+        let mut req = request(true);
+        req.id = "req_stream_01".to_string();
+        req.provider_id = "anthropic".to_string();
+
+        let response = provider.send(req.clone()).await.expect("stream response");
+        match response.body {
+            ResponseBody::Stream(descriptor) => {
+                assert_eq!(descriptor.provider, "anthropic");
+                assert_eq!(descriptor.format, "sse");
+            }
+            other => panic!("expected stream response, got {other:?}"),
+        }
+        let lines = provider
+            .stream_response_lines(&req)
+            .expect("stream lines should exist");
+        assert!(lines.iter().any(|line| line.contains("\"Hello\"")));
+        assert!(lines.iter().any(|line| line.contains("\"usage\"")));
+        assert_eq!(lines.last(), Some(&"data: [DONE]\n\n".to_string()));
+    }
+
+    #[tokio::test]
+    async fn anthropic_error_payload_is_mapped() {
+        let (base_url, _) = spawn_single_response_server(
+            401,
+            "application/json",
+            json!({
+                "type": "error",
+                "error": {
+                    "type": "authentication_error",
+                    "message": "invalid x-api-key"
+                }
+            })
+            .to_string(),
+        )
+        .await;
+
+        let provider = anthropic_provider(base_url);
+        let mut req = request(false);
+        req.provider_id = "anthropic".to_string();
+
+        let response = provider.send(req).await.expect("response");
+        assert_eq!(response.status, 401);
+        match response.body {
+            ResponseBody::Complete(payload) => {
+                assert_eq!(payload["error"]["type"], "authentication_error");
+                assert_eq!(payload["error"]["code"], 401);
+            }
+            other => panic!("expected mapped error payload, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn anthropic_unsupported_model_returns_error() {
+        let provider = AnthropicProvider::new(AnthropicProviderConfig {
+            api_key: "test-key".to_string(),
+            supported_models: vec!["claude-sonnet-4-6".to_string()],
+            ..AnthropicProviderConfig::default()
+        })
+        .expect("provider");
+        let mut req = request(false);
+        req.model_requested = "gpt-4.1".to_string();
+        req.model_resolved = "gpt-4.1".to_string();
+        req.provider_id = "anthropic".to_string();
+
+        let error = provider.send(req).await.expect_err("unsupported model");
+        assert!(matches!(error, ProviderError::UnsupportedModel(model) if model == "gpt-4.1"));
     }
 }

--- a/crates/penny-proxy/src/lib.rs
+++ b/crates/penny-proxy/src/lib.rs
@@ -258,6 +258,21 @@ async fn post_chat_completions(
                 format!("model `{model}` is not configured in the active provider"),
             );
         }
+        Err(ProviderError::InternalState(message)) => {
+            if let Some(context) = enforcement {
+                maybe_release_on_dispatch_failure(
+                    &state,
+                    &normalized.id,
+                    context.reserve_persisted,
+                )
+                .await;
+            }
+            return error_response(
+                StatusCode::BAD_GATEWAY,
+                "provider_internal_state",
+                format!("provider internal state error: {message}"),
+            );
+        }
     };
 
     let status = StatusCode::from_u16(provider_response.status).unwrap_or(StatusCode::BAD_GATEWAY);


### PR DESCRIPTION
## EPIC / Issue
- Parent EPIC: #21 (M4 Streaming and Real Providers)
- Implements: #22

## What changed
- Added `AnthropicProvider` with configurable base URL, API key, version header, and model support.
- Implemented Anthropic message payload mapping from normalized OpenAI-style requests.
- Implemented non-stream response translation to OpenAI-compatible completion payloads.
- Implemented Anthropic SSE parsing and rewritten OpenAI chunk stream with final usage chunk.
- Added upstream error mapping for non-2xx responses.
- Added proxy handling for provider internal-state errors.

## Validation
- `cargo fmt --all`
- `cargo test -p penny-providers`
- `cargo clippy -p penny-providers --all-targets -- -D warnings`
- `cargo check -p penny-proxy`
- `cargo test -p penny-proxy`
- `cargo clippy -p penny-proxy --all-targets -- -D warnings`
