### PR TITLE
feat(proxy,providers): implement streaming passthrough and reconciliation for M4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -622,6 +622,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
 
 [[package]]
+name = "futures-macro"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "futures-sink"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -641,6 +652,7 @@ checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
  "futures-core",
  "futures-io",
+ "futures-macro",
  "futures-sink",
  "futures-task",
  "memchr",
@@ -1362,6 +1374,7 @@ version = "0.1.0"
 dependencies = [
  "async-trait",
  "chrono",
+ "futures-util",
  "penny-types",
  "reqwest",
  "serde_json",
@@ -1373,7 +1386,9 @@ dependencies = [
 name = "penny-proxy"
 version = "0.1.0"
 dependencies = [
+ "async-trait",
  "axum",
+ "bytes",
  "chrono",
  "penny-budget",
  "penny-config",
@@ -1388,6 +1403,7 @@ dependencies = [
  "tempfile",
  "thiserror 1.0.69",
  "tokio",
+ "tokio-stream",
  "tower",
  "tracing",
  "uuid",
@@ -1689,6 +1705,7 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "futures-core",
+ "futures-util",
  "http",
  "http-body",
  "http-body-util",
@@ -1708,12 +1725,14 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-rustls",
+ "tokio-util",
  "tower",
  "tower-http",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-streams",
  "web-sys",
  "webpki-roots 1.0.6",
 ]
@@ -2393,6 +2412,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-util"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "toml"
 version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2736,6 +2768,19 @@ dependencies = [
  "indexmap",
  "wasm-encoder",
  "wasmparser",
+]
+
+[[package]]
+name = "wasm-streams"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
 ]
 
 [[package]]

--- a/crates/penny-providers/Cargo.toml
+++ b/crates/penny-providers/Cargo.toml
@@ -6,10 +6,12 @@ publish = false
 
 [dependencies]
 async-trait = "0.1"
+futures-util = "0.3"
 penny-types = { path = "../penny-types" }
-reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
+reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls", "stream"] }
 serde_json = "1"
 thiserror = "1"
+tokio = { version = "1", features = ["rt", "sync"] }
 
 [dev-dependencies]
 chrono = { version = "0.4", features = ["serde"] }

--- a/crates/penny-providers/src/lib.rs
+++ b/crates/penny-providers/src/lib.rs
@@ -1,6 +1,7 @@
 //! Provider adapter abstractions.
 
 use async_trait::async_trait;
+use futures_util::StreamExt;
 use penny_types::{NormalizedRequest, ProviderResponse, ResponseBody, StreamDescriptor};
 use reqwest::{header::CONTENT_TYPE, Client, StatusCode};
 use serde_json::{json, Value};
@@ -9,6 +10,7 @@ use std::{
     sync::{Mutex, MutexGuard},
 };
 use thiserror::Error;
+use tokio::sync::mpsc;
 
 #[derive(Debug, Error)]
 pub enum ProviderError {
@@ -23,6 +25,9 @@ pub trait ProviderAdapter: Send + Sync {
     async fn send(&self, req: NormalizedRequest) -> Result<ProviderResponse, ProviderError>;
     fn provider_id(&self) -> &str;
     fn supports_model(&self, model: &str) -> bool;
+    fn take_stream_receiver(&self, _req: &NormalizedRequest) -> Option<mpsc::Receiver<String>> {
+        None
+    }
     fn stream_response_lines(&self, _req: &NormalizedRequest) -> Option<Vec<String>> {
         None
     }
@@ -53,7 +58,7 @@ impl Default for OpenAiProviderConfig {
 pub struct OpenAiProvider {
     config: OpenAiProviderConfig,
     client: Client,
-    pending_streams: ArcStreamCache,
+    pending_streams: ArcReceiverCache,
 }
 
 impl OpenAiProvider {
@@ -108,25 +113,9 @@ impl OpenAiProvider {
         }
     }
 
-    fn normalize_sse_lines(&self, raw_body: &str) -> Vec<String> {
-        let mut lines = raw_body
-            .split("\n\n")
-            .filter_map(|segment| {
-                let trimmed = segment.trim();
-                if trimmed.is_empty() {
-                    return None;
-                }
-                Some(format!("{trimmed}\n\n"))
-            })
-            .collect::<Vec<_>>();
-
-        if lines.is_empty() && !raw_body.trim().is_empty() {
-            lines.push(format!("{}\n\n", raw_body.trim()));
-        }
-        lines
-    }
-
-    fn lock_streams(&self) -> Result<MutexGuard<'_, HashMap<String, Vec<String>>>, ProviderError> {
+    fn lock_streams(
+        &self,
+    ) -> Result<MutexGuard<'_, HashMap<String, mpsc::Receiver<String>>>, ProviderError> {
         self.pending_streams
             .lock()
             .map_err(|err| ProviderError::InternalState(err.to_string()))
@@ -160,10 +149,10 @@ impl Default for AnthropicProviderConfig {
 pub struct AnthropicProvider {
     config: AnthropicProviderConfig,
     client: Client,
-    pending_streams: ArcStreamCache,
+    pending_streams: ArcReceiverCache,
 }
 
-type ArcStreamCache = std::sync::Arc<Mutex<HashMap<String, Vec<String>>>>;
+type ArcReceiverCache = std::sync::Arc<Mutex<HashMap<String, mpsc::Receiver<String>>>>;
 
 #[derive(Debug, Default)]
 struct AnthropicStreamState {
@@ -173,6 +162,8 @@ struct AnthropicStreamState {
     output_tokens: Option<u64>,
     finish_reason: Option<String>,
     deltas: Vec<String>,
+    role_sent: bool,
+    done_sent: bool,
 }
 
 impl AnthropicProvider {
@@ -326,88 +317,106 @@ impl AnthropicProvider {
         })
     }
 
-    fn map_stream_lines(&self, req: &NormalizedRequest, raw_body: &str) -> Vec<String> {
-        let mut state = AnthropicStreamState::default();
-        for block in split_sse_blocks(raw_body) {
-            let event = parse_sse_event(block);
-            if event.data.eq_ignore_ascii_case("[done]") {
-                continue;
+    fn map_stream_event(
+        req: &NormalizedRequest,
+        state: &mut AnthropicStreamState,
+        event: &SseEvent,
+    ) -> Vec<String> {
+        if event.data.eq_ignore_ascii_case("[done]") {
+            if state.done_sent {
+                return Vec::new();
             }
-            let parsed: Value = match serde_json::from_str(&event.data) {
-                Ok(value) => value,
-                Err(_) => continue,
-            };
-            match event.name.as_deref() {
-                Some("message_start") => {
-                    let message = parsed.get("message").unwrap_or(&Value::Null);
-                    state.message_id = message
-                        .get("id")
-                        .and_then(Value::as_str)
-                        .map(ToOwned::to_owned);
-                    state.model = message
-                        .get("model")
-                        .and_then(Value::as_str)
-                        .map(ToOwned::to_owned);
-                    state.input_tokens = message
-                        .get("usage")
-                        .and_then(|usage| usage.get("input_tokens"))
-                        .and_then(Value::as_u64)
-                        .or(state.input_tokens);
-                    state.output_tokens = message
-                        .get("usage")
-                        .and_then(|usage| usage.get("output_tokens"))
-                        .and_then(Value::as_u64)
-                        .or(state.output_tokens);
-                }
-                Some("content_block_start") => {
-                    if let Some(text) = parsed
-                        .get("content_block")
-                        .and_then(|block| block.get("text"))
-                        .and_then(Value::as_str)
-                    {
-                        if !text.is_empty() {
-                            state.deltas.push(text.to_string());
-                        }
-                    }
-                }
-                Some("content_block_delta") => {
-                    if let Some(text) = parsed
-                        .get("delta")
-                        .and_then(|delta| delta.get("text"))
-                        .and_then(Value::as_str)
-                    {
-                        if !text.is_empty() {
-                            state.deltas.push(text.to_string());
-                        }
-                    }
-                }
-                Some("message_delta") => {
-                    state.output_tokens = parsed
-                        .get("usage")
-                        .and_then(|usage| usage.get("output_tokens"))
-                        .and_then(Value::as_u64)
-                        .or(state.output_tokens);
-                    state.finish_reason = parsed
-                        .get("delta")
-                        .and_then(|delta| delta.get("stop_reason"))
-                        .and_then(Value::as_str)
-                        .map(ToOwned::to_owned)
-                        .or(state.finish_reason);
-                }
-                Some("message_stop") => {
-                    state.finish_reason = state
-                        .finish_reason
-                        .take()
-                        .or_else(|| Some("end_turn".to_string()));
-                }
-                _ => {}
-            }
+            state.done_sent = true;
+            return vec!["data: [DONE]\n\n".to_string()];
         }
 
-        build_openai_sse_lines(req, &state)
+        let parsed: Value = match serde_json::from_str(&event.data) {
+            Ok(value) => value,
+            Err(_) => return Vec::new(),
+        };
+        match event.name.as_deref() {
+            Some("message_start") => {
+                let message = parsed.get("message").unwrap_or(&Value::Null);
+                state.message_id = message
+                    .get("id")
+                    .and_then(Value::as_str)
+                    .map(ToOwned::to_owned);
+                state.model = message
+                    .get("model")
+                    .and_then(Value::as_str)
+                    .map(ToOwned::to_owned);
+                state.input_tokens = message
+                    .get("usage")
+                    .and_then(|usage| usage.get("input_tokens"))
+                    .and_then(Value::as_u64)
+                    .or(state.input_tokens);
+                state.output_tokens = message
+                    .get("usage")
+                    .and_then(|usage| usage.get("output_tokens"))
+                    .and_then(Value::as_u64)
+                    .or(state.output_tokens);
+
+                if state.role_sent {
+                    return Vec::new();
+                }
+                state.role_sent = true;
+                vec![build_openai_role_chunk(req, state)]
+            }
+            Some("content_block_start") => parsed
+                .get("content_block")
+                .and_then(|block| block.get("text"))
+                .and_then(Value::as_str)
+                .filter(|text| !text.is_empty())
+                .map(|text| {
+                    state.deltas.push(text.to_string());
+                    vec![build_openai_delta_chunk(req, state, text)]
+                })
+                .unwrap_or_default(),
+            Some("content_block_delta") => parsed
+                .get("delta")
+                .and_then(|delta| delta.get("text"))
+                .and_then(Value::as_str)
+                .filter(|text| !text.is_empty())
+                .map(|text| {
+                    state.deltas.push(text.to_string());
+                    vec![build_openai_delta_chunk(req, state, text)]
+                })
+                .unwrap_or_default(),
+            Some("message_delta") => {
+                state.output_tokens = parsed
+                    .get("usage")
+                    .and_then(|usage| usage.get("output_tokens"))
+                    .and_then(Value::as_u64)
+                    .or(state.output_tokens);
+                state.finish_reason = parsed
+                    .get("delta")
+                    .and_then(|delta| delta.get("stop_reason"))
+                    .and_then(Value::as_str)
+                    .map(ToOwned::to_owned)
+                    .or_else(|| state.finish_reason.clone());
+                Vec::new()
+            }
+            Some("message_stop") => {
+                if state.done_sent {
+                    return Vec::new();
+                }
+                state.finish_reason = state
+                    .finish_reason
+                    .take()
+                    .or_else(|| Some("end_turn".to_string()));
+                state.done_sent = true;
+                vec![
+                    build_openai_final_chunk(req, state),
+                    "data: [DONE]\n\n".to_string(),
+                ]
+            }
+            _ => Vec::new(),
+        }
     }
 
-    fn lock_streams(&self) -> Result<MutexGuard<'_, HashMap<String, Vec<String>>>, ProviderError> {
+    fn lock_streams(
+        &self,
+    ) -> Result<MutexGuard<'_, HashMap<String, mpsc::Receiver<String>>>, ProviderError> {
         self.pending_streams
             .lock()
             .map_err(|err| ProviderError::InternalState(err.to_string()))
@@ -569,6 +578,19 @@ impl ProviderAdapter for MockProvider {
         self.config.supported_models.iter().any(|m| m == model)
     }
 
+    fn take_stream_receiver(&self, req: &NormalizedRequest) -> Option<mpsc::Receiver<String>> {
+        let lines = self.stream_sse_lines(req);
+        let (tx, rx) = mpsc::channel(lines.len().max(1));
+        tokio::spawn(async move {
+            for line in lines {
+                if tx.send(line).await.is_err() {
+                    return;
+                }
+            }
+        });
+        Some(rx)
+    }
+
     fn stream_response_lines(&self, req: &NormalizedRequest) -> Option<Vec<String>> {
         Some(self.stream_sse_lines(req))
     }
@@ -601,9 +623,8 @@ impl ProviderAdapter for AnthropicProvider {
             }
         };
         let status = response.status();
-        let body_text = response.text().await.unwrap_or_default();
-
         if !status.is_success() {
+            let body_text = response.text().await.unwrap_or_default();
             return Ok(ProviderResponse {
                 status: status.as_u16(),
                 body: ResponseBody::Complete(self.map_error_response(status, &body_text)),
@@ -612,9 +633,35 @@ impl ProviderAdapter for AnthropicProvider {
         }
 
         if req.stream {
-            let lines = self.map_stream_lines(&req, &body_text);
+            let (tx, rx) = mpsc::channel::<String>(64);
+            let stream_req = req.clone();
+            tokio::spawn(async move {
+                let mut upstream = response.bytes_stream();
+                let mut buffer = String::new();
+                let mut state = AnthropicStreamState::default();
+                while let Some(chunk_result) = upstream.next().await {
+                    let chunk = match chunk_result {
+                        Ok(bytes) => bytes,
+                        Err(_) => break,
+                    };
+                    buffer.push_str(&String::from_utf8_lossy(&chunk));
+                    for raw_event in drain_sse_events(&mut buffer) {
+                        let event = parse_sse_event(&raw_event);
+                        let mapped =
+                            AnthropicProvider::map_stream_event(&stream_req, &mut state, &event);
+                        for line in mapped {
+                            if tx.send(line).await.is_err() {
+                                return;
+                            }
+                        }
+                        if state.done_sent {
+                            return;
+                        }
+                    }
+                }
+            });
             let mut streams = self.lock_streams()?;
-            streams.insert(req.id.clone(), lines);
+            streams.insert(req.id.clone(), rx);
             return Ok(ProviderResponse {
                 status: status.as_u16(),
                 body: ResponseBody::Stream(StreamDescriptor {
@@ -625,6 +672,7 @@ impl ProviderAdapter for AnthropicProvider {
             });
         }
 
+        let body_text = response.text().await.unwrap_or_default();
         let parsed: Value = serde_json::from_str(&body_text).unwrap_or_else(|_| json!({}));
         Ok(ProviderResponse {
             status: status.as_u16(),
@@ -644,9 +692,18 @@ impl ProviderAdapter for AnthropicProvider {
         model.starts_with("claude")
     }
 
-    fn stream_response_lines(&self, req: &NormalizedRequest) -> Option<Vec<String>> {
+    fn take_stream_receiver(&self, req: &NormalizedRequest) -> Option<mpsc::Receiver<String>> {
         let mut streams = self.lock_streams().ok()?;
         streams.remove(&req.id)
+    }
+
+    fn stream_response_lines(&self, req: &NormalizedRequest) -> Option<Vec<String>> {
+        let mut receiver = self.take_stream_receiver(req)?;
+        let mut lines = Vec::new();
+        while let Ok(line) = receiver.try_recv() {
+            lines.push(line);
+        }
+        Some(lines)
     }
 }
 
@@ -677,9 +734,8 @@ impl ProviderAdapter for OpenAiProvider {
             }
         };
         let status = response.status();
-        let body_text = response.text().await.unwrap_or_default();
-
         if !status.is_success() {
+            let body_text = response.text().await.unwrap_or_default();
             return Ok(ProviderResponse {
                 status: status.as_u16(),
                 body: ResponseBody::Complete(self.map_error_response(status, &body_text)),
@@ -688,9 +744,33 @@ impl ProviderAdapter for OpenAiProvider {
         }
 
         if req.stream {
-            let lines = self.normalize_sse_lines(&body_text);
+            let (tx, rx) = mpsc::channel::<String>(64);
+            tokio::spawn(async move {
+                let mut upstream = response.bytes_stream();
+                let mut buffer = String::new();
+                while let Some(chunk_result) = upstream.next().await {
+                    let chunk = match chunk_result {
+                        Ok(bytes) => bytes,
+                        Err(_) => break,
+                    };
+                    buffer.push_str(&String::from_utf8_lossy(&chunk));
+                    for raw_event in drain_sse_events(&mut buffer) {
+                        let line = format!("{}\n\n", raw_event.trim());
+                        if tx.send(line.clone()).await.is_err() {
+                            return;
+                        }
+                        if raw_event.trim().eq_ignore_ascii_case("data: [done]") {
+                            return;
+                        }
+                    }
+                }
+                let remaining = buffer.trim();
+                if !remaining.is_empty() {
+                    let _ = tx.send(format!("{remaining}\n\n")).await;
+                }
+            });
             let mut streams = self.lock_streams()?;
-            streams.insert(req.id.clone(), lines);
+            streams.insert(req.id.clone(), rx);
             return Ok(ProviderResponse {
                 status: status.as_u16(),
                 body: ResponseBody::Stream(StreamDescriptor {
@@ -701,6 +781,7 @@ impl ProviderAdapter for OpenAiProvider {
             });
         }
 
+        let body_text = response.text().await.unwrap_or_default();
         let parsed = serde_json::from_str::<Value>(&body_text).unwrap_or_else(|_| json!({}));
         Ok(ProviderResponse {
             status: status.as_u16(),
@@ -723,9 +804,18 @@ impl ProviderAdapter for OpenAiProvider {
             || model.starts_with("omni")
     }
 
-    fn stream_response_lines(&self, req: &NormalizedRequest) -> Option<Vec<String>> {
+    fn take_stream_receiver(&self, req: &NormalizedRequest) -> Option<mpsc::Receiver<String>> {
         let mut streams = self.lock_streams().ok()?;
         streams.remove(&req.id)
+    }
+
+    fn stream_response_lines(&self, req: &NormalizedRequest) -> Option<Vec<String>> {
+        let mut receiver = self.take_stream_receiver(req)?;
+        let mut lines = Vec::new();
+        while let Ok(line) = receiver.try_recv() {
+            lines.push(line);
+        }
+        Some(lines)
     }
 }
 
@@ -735,11 +825,18 @@ struct SseEvent {
     data: String,
 }
 
-fn split_sse_blocks(raw_body: &str) -> Vec<&str> {
-    raw_body
-        .split("\n\n")
-        .filter(|chunk| !chunk.trim().is_empty())
-        .collect()
+fn drain_sse_events(buffer: &mut String) -> Vec<String> {
+    let mut events = Vec::new();
+    while let Some(idx) = buffer.find("\n\n") {
+        let raw = buffer[..idx].to_string();
+        let rest = buffer[idx + 2..].to_string();
+        *buffer = rest;
+        if raw.trim().is_empty() {
+            continue;
+        }
+        events.push(raw);
+    }
+    events
 }
 
 fn parse_sse_event(raw_event: &str) -> SseEvent {
@@ -758,18 +855,13 @@ fn parse_sse_event(raw_event: &str) -> SseEvent {
     event
 }
 
-fn build_openai_sse_lines(req: &NormalizedRequest, state: &AnthropicStreamState) -> Vec<String> {
+fn build_openai_role_chunk(req: &NormalizedRequest, state: &AnthropicStreamState) -> String {
     let message_id = state.message_id.as_deref().unwrap_or(&req.id).to_string();
     let model = state
         .model
         .as_deref()
         .unwrap_or(&req.model_resolved)
         .to_string();
-    let finish_reason = map_finish_reason(state.finish_reason.as_deref().unwrap_or("end_turn"));
-    let prompt_tokens = state.input_tokens.unwrap_or(0);
-    let completion_tokens = state.output_tokens.unwrap_or(0);
-
-    let mut lines = Vec::with_capacity(state.deltas.len() + 3);
     let first_chunk = json!({
         "id": message_id,
         "object": "chat.completion.chunk",
@@ -781,23 +873,44 @@ fn build_openai_sse_lines(req: &NormalizedRequest, state: &AnthropicStreamState)
             "finish_reason": Value::Null,
         }],
     });
-    lines.push(format!("data: {first_chunk}\n\n"));
+    format!("data: {first_chunk}\n\n")
+}
 
-    for delta in &state.deltas {
-        let chunk = json!({
-            "id": message_id,
-            "object": "chat.completion.chunk",
-            "created": req.timestamp.timestamp(),
-            "model": model,
-            "choices": [{
-                "index": 0,
-                "delta": {"content": delta},
-                "finish_reason": Value::Null,
-            }],
-        });
-        lines.push(format!("data: {chunk}\n\n"));
-    }
+fn build_openai_delta_chunk(
+    req: &NormalizedRequest,
+    state: &AnthropicStreamState,
+    delta: &str,
+) -> String {
+    let message_id = state.message_id.as_deref().unwrap_or(&req.id).to_string();
+    let model = state
+        .model
+        .as_deref()
+        .unwrap_or(&req.model_resolved)
+        .to_string();
+    let chunk = json!({
+        "id": message_id,
+        "object": "chat.completion.chunk",
+        "created": req.timestamp.timestamp(),
+        "model": model,
+        "choices": [{
+            "index": 0,
+            "delta": {"content": delta},
+            "finish_reason": Value::Null,
+        }],
+    });
+    format!("data: {chunk}\n\n")
+}
 
+fn build_openai_final_chunk(req: &NormalizedRequest, state: &AnthropicStreamState) -> String {
+    let message_id = state.message_id.as_deref().unwrap_or(&req.id).to_string();
+    let model = state
+        .model
+        .as_deref()
+        .unwrap_or(&req.model_resolved)
+        .to_string();
+    let finish_reason = map_finish_reason(state.finish_reason.as_deref().unwrap_or("end_turn"));
+    let prompt_tokens = state.input_tokens.unwrap_or(0);
+    let completion_tokens = state.output_tokens.unwrap_or(0);
     let final_chunk = json!({
         "id": message_id,
         "object": "chat.completion.chunk",
@@ -814,9 +927,7 @@ fn build_openai_sse_lines(req: &NormalizedRequest, state: &AnthropicStreamState)
             "total_tokens": prompt_tokens + completion_tokens,
         }
     });
-    lines.push(format!("data: {final_chunk}\n\n"));
-    lines.push("data: [DONE]\n\n".to_string());
-    lines
+    format!("data: {final_chunk}\n\n")
 }
 
 fn extract_message_text(content: &Value) -> Option<String> {
@@ -996,6 +1107,18 @@ mod tests {
         (format!("http://{addr}"), rx)
     }
 
+    async fn collect_stream_lines(mut receiver: mpsc::Receiver<String>) -> Vec<String> {
+        let mut lines = Vec::new();
+        while let Some(line) = receiver.recv().await {
+            let is_done = line.trim().eq_ignore_ascii_case("data: [done]");
+            lines.push(line);
+            if is_done {
+                break;
+            }
+        }
+        lines
+    }
+
     #[tokio::test]
     async fn anthropic_non_stream_is_mapped_to_openai_shape() {
         let (base_url, request_rx) = spawn_single_response_server(
@@ -1066,9 +1189,10 @@ mod tests {
             }
             other => panic!("expected stream response, got {other:?}"),
         }
-        let lines = provider
-            .stream_response_lines(&req)
-            .expect("stream lines should exist");
+        let receiver = provider
+            .take_stream_receiver(&req)
+            .expect("stream receiver should exist");
+        let lines = collect_stream_lines(receiver).await;
         assert!(lines.iter().any(|line| line.contains("\"Hello\"")));
         assert!(lines.iter().any(|line| line.contains("\"usage\"")));
         assert_eq!(lines.last(), Some(&"data: [DONE]\n\n".to_string()));
@@ -1209,9 +1333,10 @@ mod tests {
             other => panic!("expected stream response, got {other:?}"),
         }
 
-        let lines = provider
-            .stream_response_lines(&req)
-            .expect("stream lines should exist");
+        let receiver = provider
+            .take_stream_receiver(&req)
+            .expect("stream receiver should exist");
+        let lines = collect_stream_lines(receiver).await;
         assert!(lines.iter().any(|line| line.contains("\"usage\"")));
         assert!(lines
             .iter()
@@ -1239,9 +1364,10 @@ mod tests {
 
         let response = provider.send(req.clone()).await.expect("stream response");
         assert!(matches!(response.body, ResponseBody::Stream(_)));
-        let lines = provider
-            .stream_response_lines(&req)
-            .expect("stream lines should exist");
+        let receiver = provider
+            .take_stream_receiver(&req)
+            .expect("stream receiver should exist");
+        let lines = collect_stream_lines(receiver).await;
         assert!(!lines.iter().any(|line| line.contains("\"usage\"")));
         assert_eq!(lines.last(), Some(&"data: [DONE]\n\n".to_string()));
     }

--- a/crates/penny-proxy/Cargo.toml
+++ b/crates/penny-proxy/Cargo.toml
@@ -6,6 +6,7 @@ publish = false
 
 [dependencies]
 axum = "0.8"
+bytes = "1"
 chrono = { version = "0.4", features = ["serde"] }
 penny-cost = { path = "../penny-cost" }
 penny-budget = { path = "../penny-budget" }
@@ -19,10 +20,12 @@ serde_json = "1"
 sqlx = { version = "0.8", features = ["runtime-tokio-rustls", "sqlite"] }
 thiserror = "1"
 tokio = { version = "1", features = ["net", "rt"] }
+tokio-stream = "0.1"
 tracing = "0.1"
 uuid = { version = "1", features = ["serde", "v7"] }
 
 [dev-dependencies]
+async-trait = "0.1"
 tempfile = "3"
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 tower = { version = "0.5", features = ["util"] }

--- a/crates/penny-proxy/src/lib.rs
+++ b/crates/penny-proxy/src/lib.rs
@@ -1,6 +1,7 @@
 //! Proxy plane implementation for PennyPrompt.
 
 use std::{
+    convert::Infallible,
     net::SocketAddr,
     path::{Path, PathBuf},
     sync::Arc,
@@ -15,6 +16,7 @@ use axum::{
     routing::{get, post},
     Extension, Router,
 };
+use bytes::Bytes;
 use chrono::Utc;
 use penny_budget::BudgetEvaluator;
 use penny_config::{
@@ -36,7 +38,9 @@ use serde_json::{json, Value};
 use sqlx::{query, query_scalar};
 use thiserror::Error;
 use tokio::net::TcpListener;
+use tokio::sync::mpsc;
 use tokio::time::timeout;
+use tokio_stream::wrappers::ReceiverStream;
 use tracing::error;
 use uuid::Uuid;
 
@@ -314,50 +318,32 @@ async fn post_chat_completions(
             (status, Json(value)).into_response()
         }
         ResponseBody::Stream(_) => {
-            if let Some(lines) = state.provider.stream_response_lines(&normalized) {
-                let usage = provider_usage_from_sse_lines(&lines)
-                    .unwrap_or_else(|| estimated_usage_from_request(&normalized));
-                let usage_cost_usd = compute_usage_cost_or_fallback(
-                    &state,
-                    &normalized,
-                    &usage,
-                    enforcement.as_ref(),
+            if let Some(receiver) = state.provider.take_stream_receiver(&normalized) {
+                stream_passthrough_response(
+                    status,
+                    state.clone(),
+                    normalized.clone(),
+                    enforcement,
+                    receiver,
                 )
-                .await;
-                if let Some(context) = enforcement {
-                    if let Err(message) = reconcile_after_dispatch(
-                        &state,
-                        &normalized.id,
-                        usage_cost_usd,
-                        context.reserve_persisted,
-                    )
-                    .await
-                    {
-                        return internal_error_response(
-                            StatusCode::INTERNAL_SERVER_ERROR,
-                            "ledger_reconcile_failed",
-                            "failed to reconcile request accounting".to_string(),
-                            message,
-                        );
+                .await
+            } else if let Some(lines) = state.provider.stream_response_lines(&normalized) {
+                let (tx, rx) = mpsc::channel::<String>(lines.len().max(1));
+                tokio::spawn(async move {
+                    for line in lines {
+                        if tx.send(line).await.is_err() {
+                            return;
+                        }
                     }
-                }
-                if let Err(message) =
-                    persist_request_and_usage(&state, &normalized, &usage, usage_cost_usd).await
-                {
-                    return internal_error_response(
-                        StatusCode::INTERNAL_SERVER_ERROR,
-                        "persistence_failed",
-                        "failed to persist request metadata".to_string(),
-                        message,
-                    );
-                }
-
-                let mut response = (status, lines.concat()).into_response();
-                response.headers_mut().insert(
-                    header::CONTENT_TYPE,
-                    HeaderValue::from_static("text/event-stream; charset=utf-8"),
-                );
-                response
+                });
+                stream_passthrough_response(
+                    status,
+                    state.clone(),
+                    normalized.clone(),
+                    enforcement,
+                    rx,
+                )
+                .await
             } else {
                 if let Some(context) = enforcement {
                     maybe_release_on_dispatch_failure(
@@ -891,6 +877,81 @@ async fn persist_request_and_usage(
     Ok(())
 }
 
+async fn stream_passthrough_response(
+    status: StatusCode,
+    state: Arc<ProxyState>,
+    normalized: NormalizedRequest,
+    enforcement: Option<BudgetEnforcementContext>,
+    mut upstream: mpsc::Receiver<String>,
+) -> Response {
+    let (client_tx, client_rx) = mpsc::channel::<Result<Bytes, Infallible>>(64);
+    tokio::spawn(async move {
+        let mut lines = Vec::new();
+        let mut saw_done = false;
+        while let Some(line) = upstream.recv().await {
+            if line.trim().eq_ignore_ascii_case("data: [done]") {
+                saw_done = true;
+            }
+            lines.push(line.clone());
+            if client_tx.send(Ok(Bytes::from(line))).await.is_err() {
+                break;
+            }
+            if saw_done {
+                break;
+            }
+        }
+
+        let mut usage = provider_usage_from_sse_lines(&lines)
+            .unwrap_or_else(|| estimated_usage_from_request(&normalized));
+        if !saw_done {
+            mark_stream_incomplete(&mut usage);
+        }
+
+        let usage_cost_usd =
+            compute_usage_cost_or_fallback(&state, &normalized, &usage, enforcement.as_ref()).await;
+        if let Some(context) = enforcement {
+            if let Err(message) = reconcile_after_dispatch(
+                &state,
+                &normalized.id,
+                usage_cost_usd,
+                context.reserve_persisted,
+            )
+            .await
+            {
+                log_internal_error("ledger_reconcile_failed", message);
+            }
+        }
+        if let Err(message) =
+            persist_request_and_usage(&state, &normalized, &usage, usage_cost_usd).await
+        {
+            log_internal_error("persistence_failed", message);
+        }
+    });
+
+    let mut response = Response::builder()
+        .status(status)
+        .body(axum::body::Body::from_stream(ReceiverStream::new(
+            client_rx,
+        )))
+        .unwrap_or_else(|_| Response::new(axum::body::Body::empty()));
+    response.headers_mut().insert(
+        header::CONTENT_TYPE,
+        HeaderValue::from_static("text/event-stream; charset=utf-8"),
+    );
+    response
+}
+
+fn mark_stream_incomplete(usage: &mut NormalizedUsage) {
+    let mut snapshot = usage
+        .pricing_snapshot
+        .as_object()
+        .cloned()
+        .unwrap_or_default();
+    snapshot.insert("stream_incomplete".to_string(), Value::Bool(true));
+    snapshot.insert("stream_completed".to_string(), Value::Bool(false));
+    usage.pricing_snapshot = Value::Object(snapshot);
+}
+
 fn detect_git_root_from(headers: &HeaderMap) -> Option<PathBuf> {
     let start_path = header_value(headers, CWD_OVERRIDE_HEADER)
         .map(PathBuf::from)
@@ -1005,6 +1066,7 @@ fn log_internal_error(tag: &str, detail: String) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use async_trait::async_trait;
     use axum::{
         body::{to_bytes, Body},
         http::Request,
@@ -1013,11 +1075,17 @@ mod tests {
     use penny_config::{load_config, LoadOptions};
     use penny_cost::import_pricebook_files;
     use penny_store::BudgetRepo;
-    use penny_types::{Budget, Money, RouteDecision, ScopeType, WindowType};
+    use penny_types::{
+        Budget, Money, ProviderResponse, RouteDecision, ScopeType, StreamDescriptor, WindowType,
+    };
     use sqlx::Row;
+    use std::collections::HashMap;
     use std::fs;
     use std::path::PathBuf;
+    use std::sync::Mutex;
     use tempfile::TempDir;
+    use tokio::sync::mpsc;
+    use tokio::time::{sleep, Duration};
     use tower::ServiceExt;
 
     fn app() -> Router {
@@ -1029,6 +1097,81 @@ mod tests {
             .await
             .expect("create in-memory store");
         let state = ProxyState::mock_default().with_store(store.clone());
+        (build_router(state), store)
+    }
+
+    #[derive(Debug, Default)]
+    struct IncompleteStreamProvider {
+        pending: Mutex<HashMap<String, mpsc::Receiver<String>>>,
+    }
+
+    #[async_trait]
+    impl ProviderAdapter for IncompleteStreamProvider {
+        async fn send(&self, req: NormalizedRequest) -> Result<ProviderResponse, ProviderError> {
+            if !req.stream {
+                return Ok(ProviderResponse {
+                    status: 200,
+                    body: ResponseBody::Complete(json!({
+                        "id": format!("chatcmpl_{}", req.id),
+                        "object": "chat.completion",
+                        "choices": [{
+                            "index": 0,
+                            "message": {"role": "assistant", "content": "non-stream"},
+                            "finish_reason": "stop"
+                        }]
+                    })),
+                    upstream_ms: 0,
+                });
+            }
+
+            let (tx, rx) = mpsc::channel(8);
+            let req_id = req.id.clone();
+            tokio::spawn(async move {
+                let lines = vec![
+                    "data: {\"id\":\"chatcmpl_incomplete\",\"object\":\"chat.completion.chunk\",\"choices\":[{\"index\":0,\"delta\":{\"role\":\"assistant\"},\"finish_reason\":null}]}\n\n".to_string(),
+                    "data: {\"id\":\"chatcmpl_incomplete\",\"object\":\"chat.completion.chunk\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"partial\"},\"finish_reason\":null}]}\n\n".to_string(),
+                ];
+                for line in lines {
+                    if tx.send(line).await.is_err() {
+                        return;
+                    }
+                }
+            });
+            self.pending
+                .lock()
+                .expect("pending lock")
+                .insert(req_id, rx);
+
+            Ok(ProviderResponse {
+                status: 200,
+                body: ResponseBody::Stream(StreamDescriptor {
+                    provider: "incomplete".to_string(),
+                    format: "sse".to_string(),
+                }),
+                upstream_ms: 1,
+            })
+        }
+
+        fn provider_id(&self) -> &str {
+            "incomplete"
+        }
+
+        fn supports_model(&self, _model: &str) -> bool {
+            true
+        }
+
+        fn take_stream_receiver(&self, req: &NormalizedRequest) -> Option<mpsc::Receiver<String>> {
+            self.pending.lock().ok()?.remove(&req.id)
+        }
+    }
+
+    async fn app_with_incomplete_stream_provider() -> (Router, SqliteStore) {
+        let store = SqliteStore::connect("sqlite::memory:")
+            .await
+            .expect("create in-memory store");
+        let provider: Arc<dyn ProviderAdapter> = Arc::new(IncompleteStreamProvider::default());
+        let state = ProxyState::with_provider(provider, vec!["gpt-4.1".to_string()])
+            .with_store(store.clone());
         (build_router(state), store)
     }
 
@@ -1472,6 +1615,57 @@ action_on_soft = "warn"
         let text = String::from_utf8(body.to_vec()).expect("utf8 body");
         assert!(text.contains("data: [DONE]"));
         assert!(text.contains("\"usage\""));
+    }
+
+    #[tokio::test]
+    async fn interrupted_streams_are_marked_incomplete_and_accounted() {
+        let (app, store) = app_with_incomplete_stream_provider().await;
+        let request = Request::builder()
+            .method("POST")
+            .uri("/v1/chat/completions")
+            .header(header::CONTENT_TYPE, "application/json")
+            .body(Body::from(
+                json!({
+                    "model": "gpt-4.1",
+                    "messages": [{"role":"user","content":"interrupt me"}],
+                    "stream": true
+                })
+                .to_string(),
+            ))
+            .expect("build request");
+
+        let response = app.oneshot(request).await.expect("response");
+        assert_eq!(response.status(), StatusCode::OK);
+        let request_id = response
+            .headers()
+            .get(REQUEST_ID_HEADER)
+            .and_then(|value| value.to_str().ok())
+            .map(ToOwned::to_owned)
+            .expect("request id header");
+        let body = to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("read body");
+        let text = String::from_utf8(body.to_vec()).expect("utf8 body");
+        assert!(text.contains("\"partial\""));
+        assert!(!text.contains("data: [DONE]"));
+
+        sleep(Duration::from_millis(50)).await;
+        let row = sqlx::query(
+            "SELECT source, pricing_snapshot, input_tokens, output_tokens FROM request_usage WHERE request_id = ?1",
+        )
+        .bind(&request_id)
+        .fetch_one(store.pool())
+        .await
+        .expect("usage row");
+
+        assert_eq!(row.get::<String, _>("source"), "estimated");
+        let pricing_snapshot: String = row.get("pricing_snapshot");
+        let pricing_json: Value =
+            serde_json::from_str(&pricing_snapshot).expect("pricing snapshot json");
+        assert_eq!(pricing_json["stream_incomplete"], true);
+        assert_eq!(pricing_json["stream_completed"], false);
+        assert!(row.get::<i64, _>("input_tokens") > 0);
+        assert!(row.get::<i64, _>("output_tokens") > 0);
     }
 
     #[test]


### PR DESCRIPTION
## EPIC / Issue
- Parent EPIC: #21 (M4 Streaming and Real Providers)
- Implements: #24
- Closes #24

## What changed
- Added real-time SSE forwarding in proxy (chunk-by-chunk, no full response buffering before client output).
- Added background stream accumulation for accounting while forwarding.
- Added end-of-stream reconciliation and request usage persistence after stream completion.
- Added incomplete-stream handling:
  - streams that terminate without `[DONE]` are marked incomplete
  - estimated usage fallback is persisted and flagged in `pricing_snapshot`.
- Extended provider adapter contract to support streaming receivers (`take_stream_receiver`) for low-latency passthrough.
- Updated OpenAI and Anthropic adapters to stream incrementally from upstream SSE instead of buffering full stream text first.

## Tests
- Added/updated provider streaming tests for:
  - usage-present streams
  - usage-absent streams (fallback path)
  - Anthropic SSE mapping to OpenAI-compatible chunks.
- Added proxy test for interrupted stream accounting:
  - verifies persisted `source = estimated`
  - verifies `stream_incomplete = true` in `pricing_snapshot`.

## Validation
- `cargo fmt --all`
- `cargo test -p penny-providers`
- `cargo test -p penny-proxy`
- `cargo clippy -p penny-providers --all-targets -- -D warnings`
- `cargo clippy -p penny-proxy --all-targets -- -D warnings`
