### PR TITLE
feat(proxy,providers): map upstream errors and harden incomplete stream handling (#26)

### DIFF
--- a/crates/penny-admin/src/lib.rs
+++ b/crates/penny-admin/src/lib.rs
@@ -631,6 +631,7 @@ fn event_type_from_db(value: &str) -> Result<EventType, StoreError> {
         "loop_detected" => Ok(EventType::LoopDetected),
         "burn_rate_alert" => Ok(EventType::BurnRateAlert),
         "session_paused" => Ok(EventType::SessionPaused),
+        "provider_failure" => Ok(EventType::ProviderFailure),
         "mode_failsafe" => Ok(EventType::ModeFailsafe),
         _ => Err(StoreError::InvalidEnum {
             field: "events.event_type",

--- a/crates/penny-providers/src/lib.rs
+++ b/crates/penny-providers/src/lib.rs
@@ -33,6 +33,39 @@ pub trait ProviderAdapter: Send + Sync {
     }
 }
 
+fn transport_error_response(error: reqwest::Error) -> ProviderResponse {
+    let (status, error_type) = if error.is_timeout() {
+        (StatusCode::GATEWAY_TIMEOUT, "upstream_timeout")
+    } else {
+        (StatusCode::BAD_GATEWAY, "upstream_unavailable")
+    };
+    ProviderResponse {
+        status: status.as_u16(),
+        body: ResponseBody::Complete(json!({
+            "error": {
+                "message": error.to_string(),
+                "type": error_type,
+                "code": status.as_u16(),
+            }
+        })),
+        upstream_ms: 0,
+    }
+}
+
+fn parse_failure_response(error: serde_json::Error) -> ProviderResponse {
+    ProviderResponse {
+        status: StatusCode::BAD_GATEWAY.as_u16(),
+        body: ResponseBody::Complete(json!({
+            "error": {
+                "message": format!("failed to parse upstream JSON response: {error}"),
+                "type": "provider_parse_error",
+                "code": StatusCode::BAD_GATEWAY.as_u16(),
+            }
+        })),
+        upstream_ms: 0,
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct OpenAiProviderConfig {
     pub provider_id: String,
@@ -609,17 +642,7 @@ impl ProviderAdapter for AnthropicProvider {
         let response = match request.send().await {
             Ok(response) => response,
             Err(error) => {
-                return Ok(ProviderResponse {
-                    status: StatusCode::BAD_GATEWAY.as_u16(),
-                    body: ResponseBody::Complete(json!({
-                        "error": {
-                            "message": error.to_string(),
-                            "type": "upstream_unavailable",
-                            "code": StatusCode::BAD_GATEWAY.as_u16(),
-                        }
-                    })),
-                    upstream_ms: 0,
-                });
+                return Ok(transport_error_response(error));
             }
         };
         let status = response.status();
@@ -673,7 +696,10 @@ impl ProviderAdapter for AnthropicProvider {
         }
 
         let body_text = response.text().await.unwrap_or_default();
-        let parsed: Value = serde_json::from_str(&body_text).unwrap_or_else(|_| json!({}));
+        let parsed = match serde_json::from_str::<Value>(&body_text) {
+            Ok(parsed) => parsed,
+            Err(error) => return Ok(parse_failure_response(error)),
+        };
         Ok(ProviderResponse {
             status: status.as_u16(),
             body: ResponseBody::Complete(self.map_non_stream_response(&req, &parsed)),
@@ -720,17 +746,7 @@ impl ProviderAdapter for OpenAiProvider {
         let response = match request.send().await {
             Ok(response) => response,
             Err(error) => {
-                return Ok(ProviderResponse {
-                    status: StatusCode::BAD_GATEWAY.as_u16(),
-                    body: ResponseBody::Complete(json!({
-                        "error": {
-                            "message": error.to_string(),
-                            "type": "upstream_unavailable",
-                            "code": StatusCode::BAD_GATEWAY.as_u16(),
-                        }
-                    })),
-                    upstream_ms: 0,
-                });
+                return Ok(transport_error_response(error));
             }
         };
         let status = response.status();
@@ -782,7 +798,10 @@ impl ProviderAdapter for OpenAiProvider {
         }
 
         let body_text = response.text().await.unwrap_or_default();
-        let parsed = serde_json::from_str::<Value>(&body_text).unwrap_or_else(|_| json!({}));
+        let parsed = match serde_json::from_str::<Value>(&body_text) {
+            Ok(parsed) => parsed,
+            Err(error) => return Ok(parse_failure_response(error)),
+        };
         Ok(ProviderResponse {
             status: status.as_u16(),
             body: ResponseBody::Complete(parsed),
@@ -965,6 +984,7 @@ mod tests {
         io::{AsyncReadExt, AsyncWriteExt},
         net::TcpListener,
         sync::oneshot,
+        time::{sleep, Duration},
     };
 
     fn request(stream: bool) -> NormalizedRequest {
@@ -1091,8 +1111,11 @@ mod tests {
 
             let reason = match status {
                 200 => "OK",
+                429 => "Too Many Requests",
                 401 => "Unauthorized",
                 502 => "Bad Gateway",
+                503 => "Service Unavailable",
+                504 => "Gateway Timeout",
                 _ => "OK",
             };
             let response = format!(
@@ -1105,6 +1128,18 @@ mod tests {
                 .expect("write response");
         });
         (format!("http://{addr}"), rx)
+    }
+
+    async fn spawn_slow_server(delay: Duration) -> String {
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind slow server");
+        let addr = listener.local_addr().expect("local addr");
+        tokio::spawn(async move {
+            let (_stream, _) = listener.accept().await.expect("accept request");
+            sleep(delay).await;
+        });
+        format!("http://{addr}")
     }
 
     async fn collect_stream_lines(mut receiver: mpsc::Receiver<String>) -> Vec<String> {
@@ -1403,6 +1438,85 @@ mod tests {
             }
             other => panic!("expected mapped error payload, got {other:?}"),
         }
+    }
+
+    #[tokio::test]
+    async fn openai_timeout_is_mapped_to_504() {
+        let base_url = spawn_slow_server(Duration::from_millis(250)).await;
+        let provider = OpenAiProvider::new(OpenAiProviderConfig {
+            base_url,
+            api_key: "test-openai-key".to_string(),
+            timeout_ms: 25,
+            supported_models: vec!["gpt-4.1".to_string()],
+            ..OpenAiProviderConfig::default()
+        })
+        .expect("provider should build");
+        let mut req = request(false);
+        req.provider_id = "openai".to_string();
+        req.model_requested = "gpt-4.1".to_string();
+        req.model_resolved = "gpt-4.1".to_string();
+
+        let response = provider.send(req).await.expect("response");
+        assert_eq!(response.status, 504);
+        match response.body {
+            ResponseBody::Complete(payload) => {
+                assert_eq!(payload["error"]["type"], "upstream_timeout");
+                assert_eq!(payload["error"]["code"], 504);
+            }
+            other => panic!("expected mapped timeout error payload, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn openai_parse_failure_is_mapped_to_502() {
+        let (base_url, _) =
+            spawn_single_response_server(200, "application/json", "{not-json".into()).await;
+        let provider = openai_provider(base_url);
+        let mut req = request(false);
+        req.provider_id = "openai".to_string();
+        req.model_requested = "gpt-4.1".to_string();
+        req.model_resolved = "gpt-4.1".to_string();
+
+        let response = provider.send(req).await.expect("response");
+        assert_eq!(response.status, 502);
+        match response.body {
+            ResponseBody::Complete(payload) => {
+                assert_eq!(payload["error"]["type"], "provider_parse_error");
+                assert_eq!(payload["error"]["code"], 502);
+            }
+            other => panic!("expected mapped parse error payload, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn openai_http_429_and_503_are_passthrough() {
+        let (base_429, _) = spawn_single_response_server(
+            429,
+            "application/json",
+            json!({"error":{"message":"rate limited","type":"rate_limit_error"}}).to_string(),
+        )
+        .await;
+        let provider_429 = openai_provider(base_429);
+        let mut req_429 = request(false);
+        req_429.provider_id = "openai".to_string();
+        req_429.model_requested = "gpt-4.1".to_string();
+        req_429.model_resolved = "gpt-4.1".to_string();
+        let response_429 = provider_429.send(req_429).await.expect("response 429");
+        assert_eq!(response_429.status, 429);
+
+        let (base_503, _) = spawn_single_response_server(
+            503,
+            "application/json",
+            json!({"error":{"message":"upstream overloaded","type":"server_error"}}).to_string(),
+        )
+        .await;
+        let provider_503 = openai_provider(base_503);
+        let mut req_503 = request(false);
+        req_503.provider_id = "openai".to_string();
+        req_503.model_requested = "gpt-4.1".to_string();
+        req_503.model_resolved = "gpt-4.1".to_string();
+        let response_503 = provider_503.send(req_503).await.expect("response 503");
+        assert_eq!(response_503.status, 503);
     }
 
     #[tokio::test]

--- a/crates/penny-proxy/src/lib.rs
+++ b/crates/penny-proxy/src/lib.rs
@@ -27,11 +27,12 @@ use penny_cost::{estimate_tokens, PricingEngine};
 use penny_ledger::CostLedger;
 use penny_providers::{MockProvider, MockProviderConfig, ProviderAdapter, ProviderError};
 use penny_store::{
-    BudgetRepo, NewRequest, ProjectRepo, RequestRepo, SessionRepo, SqliteStore, UsageRecord,
+    BudgetRepo, EventRepo, NewEvent, NewRequest, ProjectRepo, RequestRepo, SessionRepo,
+    SqliteStore, UsageRecord,
 };
 use penny_types::{
-    Budget, BudgetBlockDetail, Mode, Money, NormalizedRequest, ResponseBody, RouteDecision,
-    ScopeType, UsageSource, WindowType,
+    Budget, BudgetBlockDetail, EventType, Mode, Money, NormalizedRequest, ResponseBody,
+    RouteDecision, ScopeType, Severity, UsageSource, WindowType,
 };
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
@@ -282,6 +283,28 @@ async fn post_chat_completions(
     let status = StatusCode::from_u16(provider_response.status).unwrap_or(StatusCode::BAD_GATEWAY);
     match provider_response.body {
         ResponseBody::Complete(value) => {
+            if !status.is_success() {
+                if let Some(context) = enforcement.as_ref() {
+                    maybe_release_on_dispatch_failure(
+                        &state,
+                        &normalized.id,
+                        context.reserve_persisted,
+                    )
+                    .await;
+                }
+                if status.is_server_error() {
+                    log_provider_failure_event(
+                        &state,
+                        &normalized,
+                        status,
+                        "upstream_http",
+                        &value,
+                    )
+                    .await;
+                }
+                return (status, Json(value)).into_response();
+            }
+
             let usage = provider_usage_from_completion(&value)
                 .unwrap_or_else(|| estimated_usage_from_request(&normalized));
             let usage_cost_usd =
@@ -905,6 +928,14 @@ async fn stream_passthrough_response(
             .unwrap_or_else(|| estimated_usage_from_request(&normalized));
         if !saw_done {
             mark_stream_incomplete(&mut usage);
+            log_provider_failure_event(
+                &state,
+                &normalized,
+                status,
+                "incomplete_stream",
+                &json!({"message":"upstream stream ended before [DONE]"}),
+            )
+            .await;
         }
 
         let usage_cost_usd =
@@ -950,6 +981,35 @@ fn mark_stream_incomplete(usage: &mut NormalizedUsage) {
     snapshot.insert("stream_incomplete".to_string(), Value::Bool(true));
     snapshot.insert("stream_completed".to_string(), Value::Bool(false));
     usage.pricing_snapshot = Value::Object(snapshot);
+}
+
+async fn log_provider_failure_event(
+    state: &ProxyState,
+    normalized: &NormalizedRequest,
+    status: StatusCode,
+    failure_kind: &'static str,
+    payload: &Value,
+) {
+    let Some(store) = &state.store else {
+        return;
+    };
+    let event = NewEvent {
+        request_id: Some(normalized.id.clone()),
+        session_id: Some(normalized.session_id.clone()),
+        event_type: EventType::ProviderFailure,
+        severity: Severity::Error,
+        detail: json!({
+            "kind": failure_kind,
+            "provider_id": normalized.provider_id,
+            "model_requested": normalized.model_requested,
+            "model_resolved": normalized.model_resolved,
+            "http_status": status.as_u16(),
+            "error": payload.get("error").cloned().unwrap_or_else(|| payload.clone()),
+        }),
+    };
+    if let Err(err) = EventRepo::insert(store, &event).await {
+        log_internal_error("provider_failure_event_insert_failed", err.to_string());
+    }
 }
 
 fn detect_git_root_from(headers: &HeaderMap) -> Option<PathBuf> {
@@ -1165,12 +1225,47 @@ mod tests {
         }
     }
 
+    #[derive(Debug, Clone)]
+    struct StaticErrorProvider {
+        status: u16,
+        payload: Value,
+    }
+
+    #[async_trait]
+    impl ProviderAdapter for StaticErrorProvider {
+        async fn send(&self, _req: NormalizedRequest) -> Result<ProviderResponse, ProviderError> {
+            Ok(ProviderResponse {
+                status: self.status,
+                body: ResponseBody::Complete(self.payload.clone()),
+                upstream_ms: 0,
+            })
+        }
+
+        fn provider_id(&self) -> &str {
+            "static-error"
+        }
+
+        fn supports_model(&self, _model: &str) -> bool {
+            true
+        }
+    }
+
     async fn app_with_incomplete_stream_provider() -> (Router, SqliteStore) {
         let store = SqliteStore::connect("sqlite::memory:")
             .await
             .expect("create in-memory store");
         let provider: Arc<dyn ProviderAdapter> = Arc::new(IncompleteStreamProvider::default());
         let state = ProxyState::with_provider(provider, vec!["gpt-4.1".to_string()])
+            .with_store(store.clone());
+        (build_router(state), store)
+    }
+
+    async fn app_with_static_error_provider(status: u16, payload: Value) -> (Router, SqliteStore) {
+        let store = SqliteStore::connect("sqlite::memory:")
+            .await
+            .expect("create in-memory store");
+        let provider: Arc<dyn ProviderAdapter> = Arc::new(StaticErrorProvider { status, payload });
+        let state = ProxyState::with_provider(provider, vec!["claude-sonnet-4-6".to_string()])
             .with_store(store.clone());
         (build_router(state), store)
     }
@@ -1666,6 +1761,17 @@ action_on_soft = "warn"
         assert_eq!(pricing_json["stream_completed"], false);
         assert!(row.get::<i64, _>("input_tokens") > 0);
         assert!(row.get::<i64, _>("output_tokens") > 0);
+
+        let detail: String = sqlx::query_scalar(
+            "SELECT detail FROM events WHERE request_id = ?1 AND event_type = 'provider_failure' ORDER BY id DESC LIMIT 1",
+        )
+        .bind(&request_id)
+        .fetch_one(store.pool())
+        .await
+        .expect("provider failure event");
+        let detail_json: Value = serde_json::from_str(&detail).expect("event detail json");
+        assert_eq!(detail_json["kind"], "incomplete_stream");
+        assert_eq!(detail_json["http_status"], 200);
     }
 
     #[test]
@@ -1787,6 +1893,101 @@ action_on_soft = "warn"
         );
         assert_eq!(json_body["error"]["budget"]["limit_usd"], 0.0);
         assert!(json_body["error"]["budget"]["resets_at"].is_string());
+    }
+
+    #[tokio::test]
+    async fn provider_429_passthrough_is_distinct_from_budget_failure() {
+        let (app, _store) = app_with_static_error_provider(
+            429,
+            json!({
+                "error": {
+                    "message": "provider rate limit",
+                    "type": "rate_limit_error",
+                    "code": 429
+                }
+            }),
+        )
+        .await;
+
+        let request = Request::builder()
+            .method("POST")
+            .uri("/v1/chat/completions")
+            .header(header::CONTENT_TYPE, "application/json")
+            .body(Body::from(
+                json!({
+                    "model": "claude-sonnet-4-6",
+                    "messages": [{"role":"user","content":"rate-limit check"}]
+                })
+                .to_string(),
+            ))
+            .expect("build request");
+
+        let response = app.oneshot(request).await.expect("response");
+        assert_eq!(response.status(), StatusCode::TOO_MANY_REQUESTS);
+        assert_ne!(response.status(), StatusCode::PAYMENT_REQUIRED);
+
+        let body = to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("read body");
+        let json_body: Value = serde_json::from_slice(&body).expect("json body");
+        assert_eq!(json_body["error"]["type"], "rate_limit_error");
+        assert!(json_body["error"]["budget"].is_null());
+        assert!(json_body["error"]["retryable"].is_null());
+    }
+
+    #[tokio::test]
+    async fn provider_5xx_passthrough_logs_provider_failure_event() {
+        let (app, store) = app_with_static_error_provider(
+            503,
+            json!({
+                "error": {
+                    "message": "upstream overloaded",
+                    "type": "server_error",
+                    "code": 503
+                }
+            }),
+        )
+        .await;
+
+        let request = Request::builder()
+            .method("POST")
+            .uri("/v1/chat/completions")
+            .header(header::CONTENT_TYPE, "application/json")
+            .body(Body::from(
+                json!({
+                    "model": "claude-sonnet-4-6",
+                    "messages": [{"role":"user","content":"5xx check"}]
+                })
+                .to_string(),
+            ))
+            .expect("build request");
+
+        let response = app.oneshot(request).await.expect("response");
+        assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
+        let request_id = response
+            .headers()
+            .get(REQUEST_ID_HEADER)
+            .and_then(|value| value.to_str().ok())
+            .map(ToOwned::to_owned)
+            .expect("request id header");
+
+        let body = to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("read body");
+        let json_body: Value = serde_json::from_slice(&body).expect("json body");
+        assert_eq!(json_body["error"]["type"], "server_error");
+
+        let detail: String = sqlx::query_scalar(
+            "SELECT detail FROM events WHERE request_id = ?1 AND event_type = 'provider_failure' ORDER BY id DESC LIMIT 1",
+        )
+        .bind(&request_id)
+        .fetch_one(store.pool())
+        .await
+        .expect("provider failure event");
+        let detail_json: Value = serde_json::from_str(&detail).expect("event detail json");
+        assert_eq!(detail_json["kind"], "upstream_http");
+        assert_eq!(detail_json["http_status"], 503);
+        assert_eq!(detail_json["provider_id"], "static-error");
     }
 
     #[tokio::test]

--- a/crates/penny-store/src/lib.rs
+++ b/crates/penny-store/src/lib.rs
@@ -844,6 +844,7 @@ fn event_type_to_db(event_type: &EventType) -> &'static str {
         EventType::LoopDetected => "loop_detected",
         EventType::BurnRateAlert => "burn_rate_alert",
         EventType::SessionPaused => "session_paused",
+        EventType::ProviderFailure => "provider_failure",
         EventType::ModeFailsafe => "mode_failsafe",
     }
 }
@@ -859,6 +860,7 @@ fn event_type_from_db(value: &str) -> Result<EventType, StoreError> {
         "loop_detected" => Ok(EventType::LoopDetected),
         "burn_rate_alert" => Ok(EventType::BurnRateAlert),
         "session_paused" => Ok(EventType::SessionPaused),
+        "provider_failure" => Ok(EventType::ProviderFailure),
         "mode_failsafe" => Ok(EventType::ModeFailsafe),
         _ => Err(StoreError::InvalidEnum {
             field: "events.event_type",

--- a/crates/penny-types/src/lib.rs
+++ b/crates/penny-types/src/lib.rs
@@ -429,6 +429,7 @@ pub enum EventType {
     LoopDetected,
     BurnRateAlert,
     SessionPaused,
+    ProviderFailure,
     ModeFailsafe,
 }
 


### PR DESCRIPTION
## Summary
- map transport timeout errors to `504` (`upstream_timeout`)
- map upstream JSON parse failures to `502` (`provider_parse_error`)
- preserve provider passthrough behavior for `429` and `5xx`
- ensure proxy upstream failures are clearly distinct from budget failures
- add technical event logging (`provider_failure`) for upstream `5xx` and incomplete streams
- extend tests across provider and proxy error paths

## Validation
- cargo test -p penny-providers -p penny-proxy -p penny-admin -p penny-store -p penny-types

Closes #26
