### PR TITLE
feat(m5): implement estimate CLI and /admin/estimate with budget impact summary (#30)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -733,6 +733,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "glob"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
 name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1318,6 +1324,7 @@ dependencies = [
  "async-stream",
  "axum",
  "chrono",
+ "penny-cost",
  "penny-proxy",
  "penny-store",
  "penny-types",
@@ -1351,11 +1358,14 @@ dependencies = [
  "chrono",
  "clap",
  "comfy-table",
+ "glob",
  "penny-config",
+ "penny-cost",
  "penny-store",
  "penny-types",
  "serde_json",
  "sqlx",
+ "tempfile",
  "thiserror 1.0.69",
  "tokio",
 ]

--- a/crates/penny-admin/Cargo.toml
+++ b/crates/penny-admin/Cargo.toml
@@ -8,6 +8,7 @@ publish = false
 async-stream = "0.3"
 axum = "0.8"
 chrono = { version = "0.4", features = ["serde"] }
+penny-cost = { path = "../penny-cost" }
 penny-store = { path = "../penny-store" }
 penny-types = { path = "../penny-types" }
 serde = { version = "1", features = ["derive"] }

--- a/crates/penny-admin/src/lib.rs
+++ b/crates/penny-admin/src/lib.rs
@@ -14,14 +14,17 @@ use axum::{
         sse::{Event as SseEvent, KeepAlive},
         IntoResponse, Response, Sse,
     },
-    routing::get,
+    routing::{get, post},
     Json, Router,
 };
 use chrono::{DateTime, Utc};
+use penny_cost::{estimate_tokens, PricingEngine};
 use penny_store::{BudgetRepo, SqliteStore, StoreError};
-use penny_types::{Budget, Event, EventType, Money, ScopeType, Severity, WindowType};
+use penny_types::{
+    Budget, CostRange, Event, EventType, Money, ScopeType, Severity, TaskType, WindowType,
+};
 use serde::{Deserialize, Serialize};
-use serde_json::json;
+use serde_json::{json, Value};
 use sqlx::{query, query_scalar, Row};
 use tokio::net::TcpListener;
 use tracing::error;
@@ -198,12 +201,65 @@ struct PricebookHealth {
     latest_effective_from: Option<String>,
 }
 
+#[derive(Debug, Deserialize)]
+struct EstimateRequest {
+    model: String,
+    #[serde(default = "default_task_type")]
+    task_type: TaskType,
+    context_tokens: Option<u64>,
+    messages: Option<Value>,
+    project_id: Option<String>,
+    session_id: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+struct EstimateResponse {
+    model: String,
+    task_type: TaskType,
+    context_tokens: u64,
+    range: CostRange,
+    pricebook_snapshot: Value,
+    route_preview: Option<RoutePreview>,
+    budget: EstimateBudgetSummary,
+}
+
+#[derive(Debug, Serialize)]
+struct RoutePreview {
+    provider_id: String,
+    provider_name: String,
+    api_format: String,
+    external_model: String,
+    enabled: bool,
+}
+
+#[derive(Debug, Serialize)]
+struct EstimateBudgetSummary {
+    status: String,
+    max_estimated_cost_usd: Money,
+    rows: Vec<EstimateBudgetRow>,
+}
+
+#[derive(Debug, Serialize)]
+struct EstimateBudgetRow {
+    budget_id: i64,
+    scope_type: ScopeType,
+    scope_id: String,
+    window_type: WindowType,
+    accumulated_usd: Money,
+    projected_usd: Money,
+    hard_limit_usd: Option<Money>,
+    soft_limit_usd: Option<Money>,
+    hard_limit_exceeded: bool,
+    soft_limit_reached: bool,
+}
+
 pub fn build_router(state: AdminState) -> Router {
     Router::new()
         .route("/admin/health", get(get_health))
         .route("/admin/report/summary", get(get_report_summary))
         .route("/admin/report/top", get(get_report_top))
         .route("/admin/budgets", get(get_budgets).post(post_budgets))
+        .route("/admin/estimate", post(post_estimate))
         .route("/admin/events", get(get_events))
         .with_state(state)
 }
@@ -435,30 +491,9 @@ async fn get_budgets(State(state): State<AdminState>) -> Response {
         }
     };
 
-    let totals_rows = query(
-        r#"
-        SELECT ledger.budget_id, ledger.running_total_micros
-        FROM cost_ledger AS ledger
-        JOIN (
-            SELECT budget_id, MAX(id) AS latest_id
-            FROM cost_ledger
-            GROUP BY budget_id
-        ) AS latest ON latest.latest_id = ledger.id
-        "#,
-    )
-    .fetch_all(state.store.pool())
-    .await
-    .unwrap_or_default();
-
-    let totals = totals_rows
-        .into_iter()
-        .map(|row| {
-            (
-                row.get::<i64, _>("budget_id"),
-                Money::from_micros(row.get("running_total_micros")),
-            )
-        })
-        .collect::<HashMap<_, _>>();
+    let totals = fetch_latest_running_totals(&state.store)
+        .await
+        .unwrap_or_default();
 
     let rows = budgets
         .into_iter()
@@ -513,6 +548,112 @@ async fn post_budgets(
         }
     };
     Json(stored).into_response()
+}
+
+async fn post_estimate(
+    State(state): State<AdminState>,
+    Json(payload): Json<EstimateRequest>,
+) -> Response {
+    let model = payload.model.trim();
+    if model.is_empty() {
+        return api_error(
+            axum::http::StatusCode::BAD_REQUEST,
+            "estimate_invalid_model",
+            "model is required".to_string(),
+        );
+    }
+
+    let context_tokens = match payload.context_tokens {
+        Some(tokens) => tokens,
+        None => {
+            let Some(messages) = payload.messages.as_ref() else {
+                return api_error(
+                    axum::http::StatusCode::BAD_REQUEST,
+                    "estimate_invalid_request",
+                    "provide context_tokens or messages".to_string(),
+                );
+            };
+            estimate_tokens(messages).input_tokens
+        }
+    };
+
+    let engine = PricingEngine::new(&state.store);
+    let range = match engine
+        .estimate_range(model, context_tokens, payload.task_type.clone())
+        .await
+    {
+        Ok(range) => range,
+        Err(error) => {
+            let status = if is_price_not_found(&error.to_string()) {
+                axum::http::StatusCode::NOT_FOUND
+            } else {
+                axum::http::StatusCode::INTERNAL_SERVER_ERROR
+            };
+            return api_error(status, "estimate_failed", error.to_string());
+        }
+    };
+    let pricebook_snapshot = match engine.snapshot(model).await {
+        Ok(snapshot) => snapshot,
+        Err(error) => {
+            let status = if is_price_not_found(&error.to_string()) {
+                axum::http::StatusCode::NOT_FOUND
+            } else {
+                axum::http::StatusCode::INTERNAL_SERVER_ERROR
+            };
+            return api_error(status, "pricebook_snapshot_failed", error.to_string());
+        }
+    };
+
+    let max_estimated_cost_usd = match Money::from_usd(range.max_usd) {
+        Ok(value) => value,
+        Err(error) => {
+            return api_error(
+                axum::http::StatusCode::INTERNAL_SERVER_ERROR,
+                "estimate_overflow",
+                error.to_string(),
+            )
+        }
+    };
+
+    let budget = match build_estimate_budget_summary(
+        &state.store,
+        payload.project_id.as_deref(),
+        payload.session_id.as_deref(),
+        max_estimated_cost_usd,
+    )
+    .await
+    {
+        Ok(summary) => summary,
+        Err(error) => {
+            return api_error(
+                axum::http::StatusCode::INTERNAL_SERVER_ERROR,
+                "estimate_budget_summary_failed",
+                error.to_string(),
+            )
+        }
+    };
+
+    let route_preview = match fetch_route_preview(&state.store, model).await {
+        Ok(preview) => preview,
+        Err(error) => {
+            return api_error(
+                axum::http::StatusCode::INTERNAL_SERVER_ERROR,
+                "estimate_route_preview_failed",
+                error.to_string(),
+            )
+        }
+    };
+
+    Json(EstimateResponse {
+        model: model.to_string(),
+        task_type: payload.task_type,
+        context_tokens,
+        range,
+        pricebook_snapshot,
+        route_preview,
+        budget,
+    })
+    .into_response()
 }
 
 async fn get_events(
@@ -605,6 +746,151 @@ async fn fetch_events_since(
     rows.into_iter().map(event_from_row).collect()
 }
 
+async fn fetch_latest_running_totals(
+    store: &SqliteStore,
+) -> Result<HashMap<i64, Money>, sqlx::Error> {
+    let rows = query(
+        r#"
+        SELECT ledger.budget_id, ledger.running_total_micros
+        FROM cost_ledger AS ledger
+        JOIN (
+            SELECT budget_id, MAX(id) AS latest_id
+            FROM cost_ledger
+            GROUP BY budget_id
+        ) AS latest ON latest.latest_id = ledger.id
+        "#,
+    )
+    .fetch_all(store.pool())
+    .await?;
+
+    Ok(rows
+        .into_iter()
+        .map(|row| {
+            (
+                row.get::<i64, _>("budget_id"),
+                Money::from_micros(row.get("running_total_micros")),
+            )
+        })
+        .collect())
+}
+
+async fn build_estimate_budget_summary(
+    store: &SqliteStore,
+    project_id: Option<&str>,
+    session_id: Option<&str>,
+    max_estimated_cost_usd: Money,
+) -> Result<EstimateBudgetSummary, StoreError> {
+    let mut budgets = if let (Some(project_id), Some(session_id)) = (project_id, session_id) {
+        store
+            .list_applicable_for_request(project_id, session_id)
+            .await?
+    } else {
+        store
+            .list_all()
+            .await?
+            .into_iter()
+            .filter(|budget| match budget.scope_type {
+                ScopeType::Global => budget.scope_id == "*",
+                ScopeType::Project => project_id.is_some_and(|project| project == budget.scope_id),
+                ScopeType::Session => session_id.is_some_and(|session| session == budget.scope_id),
+            })
+            .collect::<Vec<_>>()
+    };
+    budgets.sort_by_key(|budget| budget.id);
+
+    if budgets.is_empty() {
+        return Ok(EstimateBudgetSummary {
+            status: "no_budgets".to_string(),
+            max_estimated_cost_usd,
+            rows: Vec::new(),
+        });
+    }
+
+    let running_totals = fetch_latest_running_totals(store).await.unwrap_or_default();
+    let mut rows = Vec::with_capacity(budgets.len());
+    let mut hard_limit_exceeded = false;
+    let mut soft_limit_reached = false;
+
+    for budget in budgets {
+        let accumulated_usd = running_totals
+            .get(&budget.id)
+            .copied()
+            .unwrap_or(Money::ZERO);
+        let projected_usd = accumulated_usd
+            .checked_add(max_estimated_cost_usd)
+            .unwrap_or(Money::from_micros(i64::MAX));
+        let hard_exceeded = budget
+            .hard_limit_usd
+            .map(|limit| projected_usd > limit)
+            .unwrap_or(false);
+        let soft_reached = budget
+            .soft_limit_usd
+            .map(|limit| projected_usd >= limit)
+            .unwrap_or(false);
+
+        hard_limit_exceeded |= hard_exceeded;
+        soft_limit_reached |= soft_reached;
+
+        rows.push(EstimateBudgetRow {
+            budget_id: budget.id,
+            scope_type: budget.scope_type,
+            scope_id: budget.scope_id,
+            window_type: budget.window_type,
+            accumulated_usd,
+            projected_usd,
+            hard_limit_usd: budget.hard_limit_usd,
+            soft_limit_usd: budget.soft_limit_usd,
+            hard_limit_exceeded: hard_exceeded,
+            soft_limit_reached: soft_reached,
+        });
+    }
+
+    let status = if hard_limit_exceeded {
+        "over_hard_limit"
+    } else if soft_limit_reached {
+        "soft_limit_reached"
+    } else {
+        "within_limit"
+    };
+
+    Ok(EstimateBudgetSummary {
+        status: status.to_string(),
+        max_estimated_cost_usd,
+        rows,
+    })
+}
+
+async fn fetch_route_preview(
+    store: &SqliteStore,
+    model_id: &str,
+) -> Result<Option<RoutePreview>, sqlx::Error> {
+    let row = query(
+        r#"
+        SELECT
+            providers.id AS provider_id,
+            providers.name AS provider_name,
+            providers.api_format AS api_format,
+            providers.enabled AS provider_enabled,
+            models.external_name AS external_model
+        FROM models
+        JOIN providers ON providers.id = models.provider_id
+        WHERE models.id = ?1
+        LIMIT 1
+        "#,
+    )
+    .bind(model_id)
+    .fetch_optional(store.pool())
+    .await?;
+
+    Ok(row.map(|row| RoutePreview {
+        provider_id: row.get("provider_id"),
+        provider_name: row.get("provider_name"),
+        api_format: row.get("api_format"),
+        external_model: row.get("external_model"),
+        enabled: row.get::<i64, _>("provider_enabled") != 0,
+    }))
+}
+
 fn event_from_row(row: sqlx::sqlite::SqliteRow) -> Result<Event, StoreError> {
     let event_type: String = row.get("event_type");
     let severity: String = row.get("severity");
@@ -664,6 +950,14 @@ fn parse_db_datetime(value: String, field: &'static str) -> Result<DateTime<Utc>
     }
 
     Err(StoreError::InvalidTimestamp { field, value })
+}
+
+fn default_task_type() -> TaskType {
+    TaskType::SinglePass
+}
+
+fn is_price_not_found(message: &str) -> bool {
+    message.starts_with("no active pricebook entry found")
 }
 
 fn ratio(accumulated: Money, limit: Option<Money>) -> Option<f64> {
@@ -776,6 +1070,51 @@ mod tests {
         )
         .await
         .expect("insert event");
+    }
+
+    async fn seed_estimate_pricing(store: &SqliteStore, model_id: &str, provider_id: &str) {
+        query(
+            r#"
+            INSERT INTO providers (id, name, base_url, api_format, enabled)
+            VALUES (?1, 'Anthropic', 'https://api.anthropic.com', 'anthropic', 1)
+            "#,
+        )
+        .bind(provider_id)
+        .execute(store.pool())
+        .await
+        .expect("insert provider");
+
+        query(
+            r#"
+            INSERT INTO models (id, provider_id, external_name, display_name, class)
+            VALUES (?1, ?2, ?3, ?3, 'balanced')
+            "#,
+        )
+        .bind(model_id)
+        .bind(provider_id)
+        .bind(model_id)
+        .execute(store.pool())
+        .await
+        .expect("insert model");
+
+        query(
+            r#"
+            INSERT INTO pricebook_entries (
+                model_id,
+                input_per_mtok,
+                output_per_mtok,
+                input_per_mtok_micros,
+                output_per_mtok_micros,
+                effective_from,
+                source
+            )
+            VALUES (?1, 3.0, 15.0, 3000000, 15000000, datetime('now', '-1 day'), 'test')
+            "#,
+        )
+        .bind(model_id)
+        .execute(store.pool())
+        .await
+        .expect("insert pricebook");
     }
 
     #[tokio::test]
@@ -920,6 +1259,48 @@ mod tests {
             .expect("read body");
         let text = String::from_utf8(body.to_vec()).expect("utf8 body");
         assert!(text.contains("event: event") || text.contains("event: heartbeat"));
+    }
+
+    #[tokio::test]
+    async fn estimate_endpoint_returns_range_route_and_budget_summary() {
+        let store = setup_store().await;
+        seed_minimal_data(&store).await;
+        seed_estimate_pricing(&store, "claude-sonnet-4-6", "anthropic").await;
+        let app = build_router(AdminState::new(store));
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/admin/estimate")
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(
+                        json!({
+                            "model": "claude-sonnet-4-6",
+                            "task_type": "multi_round",
+                            "context_tokens": 1200,
+                            "project_id": "pennyprompt-admin",
+                            "session_id": "not-present"
+                        })
+                        .to_string(),
+                    ))
+                    .expect("build request"),
+            )
+            .await
+            .expect("response");
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("read body");
+        let json_body: Value = serde_json::from_slice(&body).expect("json body");
+
+        assert_eq!(json_body["model"], "claude-sonnet-4-6");
+        assert_eq!(json_body["task_type"], "multi_round");
+        assert_eq!(json_body["context_tokens"], 1200);
+        assert_eq!(json_body["range"]["confidence"], "medium");
+        assert_eq!(json_body["route_preview"]["provider_id"], "anthropic");
+        assert_eq!(json_body["budget"]["status"], "within_limit");
+        assert_eq!(json_body["budget"]["rows"][0]["accumulated_usd"], 2.5);
     }
 
     #[tokio::test]

--- a/crates/penny-cli/Cargo.toml
+++ b/crates/penny-cli/Cargo.toml
@@ -8,6 +8,8 @@ publish = false
 chrono = { version = "0.4", features = ["serde"] }
 clap = { version = "4", features = ["derive"] }
 comfy-table = "7"
+glob = "0.3"
+penny-cost = { path = "../penny-cost" }
 penny-config = { path = "../penny-config" }
 penny-store = { path = "../penny-store" }
 penny-types = { path = "../penny-types" }
@@ -15,3 +17,6 @@ serde_json = "1"
 sqlx = { version = "0.8", features = ["runtime-tokio-rustls", "sqlite"] }
 thiserror = "1"
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
+
+[dev-dependencies]
+tempfile = "3"

--- a/crates/penny-cli/src/main.rs
+++ b/crates/penny-cli/src/main.rs
@@ -1,10 +1,19 @@
-use std::{path::PathBuf, time::Duration};
+use std::{
+    collections::{BTreeSet, HashMap},
+    fs,
+    path::{Path, PathBuf},
+    time::Duration,
+};
 
 use chrono::{DateTime, Utc};
 use clap::{Parser, Subcommand, ValueEnum};
 use comfy_table::{presets::UTF8_FULL, Attribute, Cell, Table};
+use glob::glob;
 use penny_config::{load_config, LoadOptions};
-use penny_store::SqliteStore;
+use penny_cost::{estimate_tokens, PricingEngine};
+use penny_store::{BudgetRepo, ProjectRepo, SqliteStore};
+use penny_types::{Confidence, Money, ScopeType, TaskType, WindowType};
+use serde_json::Value;
 use sqlx::{query, Row};
 use thiserror::Error;
 
@@ -20,6 +29,22 @@ struct Cli {
 
 #[derive(Debug, Subcommand)]
 enum Commands {
+    Estimate {
+        #[arg(long)]
+        model: String,
+        #[arg(long, value_enum, default_value_t = EstimateTaskType::SinglePass)]
+        task_type: EstimateTaskType,
+        #[arg(long)]
+        context_tokens: Option<u64>,
+        #[arg(long = "context-files")]
+        context_files: Vec<String>,
+        #[arg(long)]
+        project_id: Option<String>,
+        #[arg(long)]
+        session_id: Option<String>,
+        #[arg(long, default_value_t = 200)]
+        max_files: usize,
+    },
     Report {
         #[command(subcommand)]
         command: ReportCommands,
@@ -43,6 +68,31 @@ enum SummaryBy {
     Session,
 }
 
+#[derive(Debug, Clone, Copy, ValueEnum)]
+enum EstimateTaskType {
+    SinglePass,
+    MultiRound,
+    AgentTask,
+}
+
+impl EstimateTaskType {
+    fn as_task_type(self) -> TaskType {
+        match self {
+            Self::SinglePass => TaskType::SinglePass,
+            Self::MultiRound => TaskType::MultiRound,
+            Self::AgentTask => TaskType::AgentTask,
+        }
+    }
+
+    fn as_label(self) -> &'static str {
+        match self {
+            Self::SinglePass => "single_pass",
+            Self::MultiRound => "multi_round",
+            Self::AgentTask => "agent_task",
+        }
+    }
+}
+
 impl SummaryBy {
     fn as_str(self) -> &'static str {
         match self {
@@ -62,14 +112,87 @@ struct SummaryRow {
     total_cost_usd: f64,
 }
 
+#[derive(Debug, Clone)]
+struct ContextEstimate {
+    tokens: u64,
+    file_count: usize,
+    source: String,
+}
+
+#[derive(Debug, Clone)]
+struct RoutePreview {
+    provider_id: String,
+    provider_name: String,
+    api_format: String,
+    external_model: String,
+    enabled: bool,
+}
+
+#[derive(Debug, Clone)]
+struct BudgetEstimateSummary {
+    status: String,
+    max_estimated_cost_usd: Money,
+    rows: Vec<BudgetEstimateRow>,
+}
+
+#[derive(Debug, Clone)]
+struct BudgetEstimateRow {
+    budget_id: i64,
+    scope_type: ScopeType,
+    scope_id: String,
+    window_type: WindowType,
+    accumulated_usd: Money,
+    projected_usd: Money,
+    hard_limit_usd: Option<Money>,
+    soft_limit_usd: Option<Money>,
+    hard_limit_exceeded: bool,
+    soft_limit_reached: bool,
+}
+
+#[derive(Debug, Clone)]
+struct EstimateCommand {
+    model: String,
+    task_type: EstimateTaskType,
+    context_tokens: Option<u64>,
+    context_files: Vec<String>,
+    project_id: Option<String>,
+    session_id: Option<String>,
+    max_files: usize,
+}
+
+#[derive(Debug)]
+struct EstimateSummary<'a> {
+    model: &'a str,
+    task_type: EstimateTaskType,
+    context: &'a ContextEstimate,
+    confidence: &'a Confidence,
+    min_usd: f64,
+    max_usd: f64,
+    route_preview: Option<&'a RoutePreview>,
+    budget: &'a BudgetEstimateSummary,
+    pricebook_snapshot: &'a Value,
+    project_id: Option<&'a str>,
+    session_id: Option<&'a str>,
+}
+
 #[derive(Debug, Error)]
 enum CliError {
     #[error("config error: {0}")]
     Config(String),
     #[error("store error: {0}")]
     Store(String),
+    #[error("cost error: {0}")]
+    Cost(String),
     #[error("invalid --since value `{0}`. Expected format like 30m, 12h, or 7d")]
     InvalidSince(String),
+    #[error("estimate requires --context-tokens or --context-files")]
+    MissingEstimateContext,
+    #[error("invalid context glob `{pattern}`: {reason}")]
+    InvalidContextGlob { pattern: String, reason: String },
+    #[error("no files matched --context-files")]
+    NoContextFilesMatched,
+    #[error("failed to read context file `{path}`: {reason}")]
+    ContextFileRead { path: String, reason: String },
 }
 
 #[tokio::main]
@@ -84,6 +207,29 @@ async fn main() {
 async fn run(cli: Cli) -> Result<(), CliError> {
     let store = open_store(cli.database).await?;
     match cli.command {
+        Commands::Estimate {
+            model,
+            task_type,
+            context_tokens,
+            context_files,
+            project_id,
+            session_id,
+            max_files,
+        } => {
+            run_estimate(
+                &store,
+                EstimateCommand {
+                    model,
+                    task_type,
+                    context_tokens,
+                    context_files,
+                    project_id,
+                    session_id,
+                    max_files,
+                },
+            )
+            .await?;
+        }
         Commands::Report { command } => match command {
             ReportCommands::Summary { since, by } => {
                 let cutoff = since
@@ -106,6 +252,375 @@ async fn run(cli: Cli) -> Result<(), CliError> {
         },
     }
     Ok(())
+}
+
+async fn run_estimate(store: &SqliteStore, command: EstimateCommand) -> Result<(), CliError> {
+    let context = estimate_context(
+        command.context_tokens,
+        &command.context_files,
+        command.max_files,
+    )?;
+    let resolved_project_id = match command.project_id {
+        Some(project_id) => Some(project_id),
+        None => autodetect_project_id(store).await?,
+    };
+
+    let engine = PricingEngine::new(store);
+    let range = engine
+        .estimate_range(
+            command.model.as_str(),
+            context.tokens,
+            command.task_type.as_task_type(),
+        )
+        .await
+        .map_err(|error| CliError::Cost(error.to_string()))?;
+    let pricebook_snapshot = engine
+        .snapshot(command.model.as_str())
+        .await
+        .map_err(|error| CliError::Cost(error.to_string()))?;
+    let route_preview = fetch_route_preview(store, command.model.as_str())
+        .await
+        .map_err(|error| CliError::Store(error.to_string()))?;
+    let max_estimated_cost_usd =
+        Money::from_usd(range.max_usd).map_err(|error| CliError::Cost(error.to_string()))?;
+    let budget = build_budget_estimate_summary(
+        store,
+        resolved_project_id.as_deref(),
+        command.session_id.as_deref(),
+        max_estimated_cost_usd,
+    )
+    .await?;
+
+    print_estimate_summary(EstimateSummary {
+        model: command.model.as_str(),
+        task_type: command.task_type,
+        context: &context,
+        confidence: &range.confidence,
+        min_usd: range.min_usd,
+        max_usd: range.max_usd,
+        route_preview: route_preview.as_ref(),
+        budget: &budget,
+        pricebook_snapshot: &pricebook_snapshot,
+        project_id: resolved_project_id.as_deref(),
+        session_id: command.session_id.as_deref(),
+    });
+    Ok(())
+}
+
+async fn autodetect_project_id(store: &SqliteStore) -> Result<Option<String>, CliError> {
+    let cwd = std::env::current_dir().map_err(|error| CliError::Config(error.to_string()))?;
+    let project = store
+        .get_by_path(&cwd.to_string_lossy())
+        .await
+        .map_err(|error| CliError::Store(error.to_string()))?;
+    Ok(project.map(|project| project.id))
+}
+
+fn estimate_context(
+    context_tokens: Option<u64>,
+    context_files: &[String],
+    max_files: usize,
+) -> Result<ContextEstimate, CliError> {
+    if let Some(tokens) = context_tokens {
+        return Ok(ContextEstimate {
+            tokens,
+            file_count: 0,
+            source: "manual".to_string(),
+        });
+    }
+
+    if context_files.is_empty() {
+        return Err(CliError::MissingEstimateContext);
+    }
+
+    let files = expand_context_patterns(context_files, max_files)?;
+    if files.is_empty() {
+        return Err(CliError::NoContextFilesMatched);
+    }
+
+    let mut content = String::new();
+    for path in &files {
+        let raw = fs::read(path).map_err(|error| CliError::ContextFileRead {
+            path: path.to_string_lossy().to_string(),
+            reason: error.to_string(),
+        })?;
+        content.push_str(&String::from_utf8_lossy(&raw));
+        content.push('\n');
+    }
+
+    let estimate = estimate_tokens(&Value::String(content));
+    Ok(ContextEstimate {
+        tokens: estimate.input_tokens,
+        file_count: files.len(),
+        source: format!("{:?}", estimate.source).to_lowercase(),
+    })
+}
+
+fn expand_context_patterns(
+    patterns: &[String],
+    max_files: usize,
+) -> Result<Vec<PathBuf>, CliError> {
+    let mut files = BTreeSet::<PathBuf>::new();
+    for pattern in patterns {
+        let entries = glob(pattern).map_err(|error| CliError::InvalidContextGlob {
+            pattern: pattern.clone(),
+            reason: error.to_string(),
+        })?;
+        for entry in entries {
+            let path = entry.map_err(|error| CliError::InvalidContextGlob {
+                pattern: pattern.clone(),
+                reason: error.to_string(),
+            })?;
+            collect_paths(path.as_path(), &mut files, max_files)?;
+            if files.len() >= max_files {
+                return Ok(files.into_iter().collect());
+            }
+        }
+    }
+
+    Ok(files.into_iter().collect())
+}
+
+fn collect_paths(
+    path: &Path,
+    files: &mut BTreeSet<PathBuf>,
+    max_files: usize,
+) -> Result<(), CliError> {
+    if files.len() >= max_files {
+        return Ok(());
+    }
+
+    if path.is_file() {
+        files.insert(path.to_path_buf());
+        return Ok(());
+    }
+
+    if !path.is_dir() {
+        return Ok(());
+    }
+
+    let entries = fs::read_dir(path).map_err(|error| CliError::ContextFileRead {
+        path: path.to_string_lossy().to_string(),
+        reason: error.to_string(),
+    })?;
+    for entry in entries {
+        let entry = entry.map_err(|error| CliError::ContextFileRead {
+            path: path.to_string_lossy().to_string(),
+            reason: error.to_string(),
+        })?;
+        collect_paths(entry.path().as_path(), files, max_files)?;
+        if files.len() >= max_files {
+            break;
+        }
+    }
+
+    Ok(())
+}
+
+async fn fetch_route_preview(
+    store: &SqliteStore,
+    model_id: &str,
+) -> Result<Option<RoutePreview>, sqlx::Error> {
+    let row = query(
+        r#"
+        SELECT
+            providers.id AS provider_id,
+            providers.name AS provider_name,
+            providers.api_format AS api_format,
+            providers.enabled AS provider_enabled,
+            models.external_name AS external_model
+        FROM models
+        JOIN providers ON providers.id = models.provider_id
+        WHERE models.id = ?1
+        LIMIT 1
+        "#,
+    )
+    .bind(model_id)
+    .fetch_optional(store.pool())
+    .await?;
+
+    Ok(row.map(|row| RoutePreview {
+        provider_id: row.get("provider_id"),
+        provider_name: row.get("provider_name"),
+        api_format: row.get("api_format"),
+        external_model: row.get("external_model"),
+        enabled: row.get::<i64, _>("provider_enabled") != 0,
+    }))
+}
+
+async fn build_budget_estimate_summary(
+    store: &SqliteStore,
+    project_id: Option<&str>,
+    session_id: Option<&str>,
+    max_estimated_cost_usd: Money,
+) -> Result<BudgetEstimateSummary, CliError> {
+    let mut budgets = if let (Some(project_id), Some(session_id)) = (project_id, session_id) {
+        store
+            .list_applicable_for_request(project_id, session_id)
+            .await
+            .map_err(|error| CliError::Store(error.to_string()))?
+    } else {
+        store
+            .list_all()
+            .await
+            .map_err(|error| CliError::Store(error.to_string()))?
+            .into_iter()
+            .filter(|budget| match budget.scope_type {
+                ScopeType::Global => budget.scope_id == "*",
+                ScopeType::Project => project_id.is_some_and(|id| id == budget.scope_id),
+                ScopeType::Session => session_id.is_some_and(|id| id == budget.scope_id),
+            })
+            .collect::<Vec<_>>()
+    };
+    budgets.sort_by_key(|budget| budget.id);
+
+    if budgets.is_empty() {
+        return Ok(BudgetEstimateSummary {
+            status: "no_budgets".to_string(),
+            max_estimated_cost_usd,
+            rows: Vec::new(),
+        });
+    }
+
+    let running_totals = fetch_latest_running_totals(store).await?;
+    let mut rows = Vec::with_capacity(budgets.len());
+    let mut hard_limit_exceeded = false;
+    let mut soft_limit_reached = false;
+
+    for budget in budgets {
+        let accumulated_usd = running_totals
+            .get(&budget.id)
+            .copied()
+            .unwrap_or(Money::ZERO);
+        let projected_usd = accumulated_usd
+            .checked_add(max_estimated_cost_usd)
+            .unwrap_or(Money::from_micros(i64::MAX));
+        let hard_exceeded = budget
+            .hard_limit_usd
+            .map(|limit| projected_usd > limit)
+            .unwrap_or(false);
+        let soft_reached = budget
+            .soft_limit_usd
+            .map(|limit| projected_usd >= limit)
+            .unwrap_or(false);
+
+        hard_limit_exceeded |= hard_exceeded;
+        soft_limit_reached |= soft_reached;
+
+        rows.push(BudgetEstimateRow {
+            budget_id: budget.id,
+            scope_type: budget.scope_type,
+            scope_id: budget.scope_id,
+            window_type: budget.window_type,
+            accumulated_usd,
+            projected_usd,
+            hard_limit_usd: budget.hard_limit_usd,
+            soft_limit_usd: budget.soft_limit_usd,
+            hard_limit_exceeded: hard_exceeded,
+            soft_limit_reached: soft_reached,
+        });
+    }
+
+    let status = if hard_limit_exceeded {
+        "over_hard_limit"
+    } else if soft_limit_reached {
+        "soft_limit_reached"
+    } else {
+        "within_limit"
+    };
+
+    Ok(BudgetEstimateSummary {
+        status: status.to_string(),
+        max_estimated_cost_usd,
+        rows,
+    })
+}
+
+async fn fetch_latest_running_totals(store: &SqliteStore) -> Result<HashMap<i64, Money>, CliError> {
+    let rows = query(
+        r#"
+        SELECT ledger.budget_id, ledger.running_total_micros
+        FROM cost_ledger AS ledger
+        JOIN (
+            SELECT budget_id, MAX(id) AS latest_id
+            FROM cost_ledger
+            GROUP BY budget_id
+        ) AS latest ON latest.latest_id = ledger.id
+        "#,
+    )
+    .fetch_all(store.pool())
+    .await
+    .map_err(|error| CliError::Store(error.to_string()))?;
+
+    Ok(rows
+        .into_iter()
+        .map(|row| {
+            (
+                row.get::<i64, _>("budget_id"),
+                Money::from_micros(row.get("running_total_micros")),
+            )
+        })
+        .collect())
+}
+
+fn print_estimate_summary(summary: EstimateSummary<'_>) {
+    println!("Estimate");
+    println!("  model: {}", summary.model);
+    println!("  task_type: {}", summary.task_type.as_label());
+    println!(
+        "  context: {} tokens (source: {}, files: {})",
+        summary.context.tokens, summary.context.source, summary.context.file_count
+    );
+    println!(
+        "  range_usd: {:.6} - {:.6}",
+        summary.min_usd, summary.max_usd
+    );
+    println!(
+        "  confidence: {}",
+        match summary.confidence {
+            Confidence::High => "high",
+            Confidence::Medium => "medium",
+            Confidence::Low => "low",
+        }
+    );
+    if let Some(route) = summary.route_preview {
+        println!(
+            "  route_preview: provider={} ({}, api={}) external_model={} enabled={}",
+            route.provider_id,
+            route.provider_name,
+            route.api_format,
+            route.external_model,
+            route.enabled
+        );
+    } else {
+        println!("  route_preview: unavailable (model not found in routing table)");
+    }
+    println!(
+        "  budget: status={} max_estimated_cost_usd={}",
+        summary.budget.status, summary.budget.max_estimated_cost_usd
+    );
+    if let Some(project_id) = summary.project_id {
+        println!("  project_id: {project_id}");
+    }
+    if let Some(session_id) = summary.session_id {
+        println!("  session_id: {session_id}");
+    }
+    for row in &summary.budget.rows {
+        println!(
+            "  budget_row: id={} scope={:?}:{} window={:?} accumulated={} projected={} hard_limit={:?} soft_limit={:?} hard_exceeded={} soft_reached={}",
+            row.budget_id,
+            row.scope_type,
+            row.scope_id,
+            row.window_type,
+            row.accumulated_usd,
+            row.projected_usd,
+            row.hard_limit_usd,
+            row.soft_limit_usd,
+            row.hard_limit_exceeded,
+            row.soft_limit_reached
+        );
+    }
+    println!("  pricebook_snapshot: {}", summary.pricebook_snapshot);
 }
 
 async fn open_store(database_override: Option<PathBuf>) -> Result<SqliteStore, CliError> {
@@ -276,9 +791,12 @@ fn print_summary_table(by: SummaryBy, since: Option<&str>, rows: &[SummaryRow]) 
 
 #[cfg(test)]
 mod tests {
+    use std::fs;
+
     use chrono::Duration as ChronoDuration;
     use penny_store::{NewRequest, ProjectRepo, RequestRepo, UsageRecord};
     use penny_types::{Money, UsageSource};
+    use tempfile::tempdir;
 
     use super::*;
 
@@ -353,6 +871,33 @@ mod tests {
         assert!(parse_since_duration("xyz").is_err());
         assert!(parse_since_duration("10").is_err());
         assert!(parse_since_duration("3w").is_err());
+    }
+
+    #[test]
+    fn estimate_context_from_context_files_glob() {
+        let dir = tempdir().expect("temp dir");
+        let root = dir.path();
+        fs::create_dir_all(root.join("src/nested")).expect("mkdir");
+        fs::write(root.join("src/lib.rs"), "fn a() { println!(\"hello\"); }").expect("write");
+        fs::write(root.join("src/nested/mod.rs"), "pub fn b() {}").expect("write");
+
+        let pattern = format!("{}/src/**/*.rs", root.display());
+        let estimate = estimate_context(None, &[pattern], 100).expect("estimate context");
+        assert_eq!(estimate.file_count, 2);
+        assert!(estimate.tokens > 0);
+    }
+
+    #[test]
+    fn estimate_context_requires_tokens_or_files() {
+        let error = estimate_context(None, &[], 100).expect_err("missing context must fail");
+        assert!(matches!(error, CliError::MissingEstimateContext));
+    }
+
+    #[test]
+    fn estimate_context_fails_when_no_files_match() {
+        let error = estimate_context(None, &[String::from("/tmp/does-not-exist/**/*.rs")], 100)
+            .expect_err("expected no matches");
+        assert!(matches!(error, CliError::NoContextFilesMatched));
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
- add `POST /admin/estimate` in admin plane
- return estimate range (`min_usd`, `max_usd`, `confidence`) using active pricebook
- include `pricebook_snapshot` for reproducibility and `route_preview` for provider/model routing
- add budget impact projection (`within_limit`, `soft_limit_reached`, `over_hard_limit`, `no_budgets`)
- add `pennyprompt estimate` CLI command with:
  - `--context-files` glob-based context estimation
  - `--context-tokens` override
  - `--task-type` range profile selection
  - printed budget impact + route preview

## Testing
- `cargo fmt --all`
- `cargo check --workspace`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked`

Closes #30
