### PR TITLE
docs(m6): add alpha documentation set (install, quickstart, config, architecture, pricebook, limitations) (#35)

### DIFF
--- a/README.md
+++ b/README.md
@@ -369,7 +369,7 @@ PennyPrompt works with any tool that speaks the OpenAI chat completions API:
 - [ ] **Post-alpha** — Launcher (`pennyprompt run <agent>`), TUI dashboard, payload cleanup, webhooks
 - [ ] **v1.0** — Team mode, PostgreSQL backend, plugin system, Grafana/Prometheus metrics
 
-See [docs/PennyPrompt-v2.md](docs/PennyPrompt-v2.md) for the full project specification.
+See [PennyPrompt-v2.md](PennyPrompt-v2.md) for the full project specification.
 
 ## Contributing
 
@@ -390,6 +390,15 @@ cargo run -- serve --mock
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines and [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) for the crate dependency map.
 For the day-to-day issue workflow used in this repo, see [docs/DEVELOPMENT_WORKFLOW.md](docs/DEVELOPMENT_WORKFLOW.md).
+
+Alpha documentation set:
+
+- [docs/INSTALL.md](docs/INSTALL.md)
+- [docs/QUICKSTART.md](docs/QUICKSTART.md)
+- [docs/CONFIG-REFERENCE.md](docs/CONFIG-REFERENCE.md)
+- [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md)
+- [docs/PRICEBOOK.md](docs/PRICEBOOK.md)
+- [docs/LIMITATIONS.md](docs/LIMITATIONS.md)
 
 ## License
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,99 @@
+# PennyPrompt Architecture (Alpha)
+
+This document describes the current repository architecture and runtime boundaries.
+
+## Workspace Layout
+
+```text
+crates/
+  penny-types/      Shared domain types and enums
+  penny-config/     Config loading, merge rules, validation
+  penny-store/      SQLite repositories + migrations + WAL mode
+  penny-cost/       Token estimation + pricebook pricing + estimation ranges
+  penny-ledger/     Atomic reserve/reconcile/release ledger flow
+  penny-budget/     Budget evaluation for observe/guard modes
+  penny-detect/     Loop and burn-rate detection engine
+  penny-providers/  Provider adapters and response normalization
+  penny-proxy/      Request pipeline and provider dispatch path
+  penny-admin/      Admin HTTP API and SSE events stream
+  penny-cli/        Operator CLI interface
+  penny-observe/    Tracing/logging support
+```
+
+## Data Model (SQLite)
+
+Primary relational flow:
+
+```text
+projects -> sessions -> requests -> request_usage
+                          |
+                          +-> events
+
+budgets
+cost_ledger (append-only accounting rows)
+pricebook_entries (versioned by effective window)
+providers / models (routing metadata)
+```
+
+Key properties:
+
+- `cost_ledger` is append-only.
+- pricing is time-versioned with `effective_from/effective_until`.
+- event history is persisted in `events`.
+
+## Runtime Planes
+
+## Proxy Plane
+
+- Accepts OpenAI-compatible request shape.
+- Normalizes request.
+- Estimates cost.
+- Runs budget evaluation (`observe` or `guard`).
+- Dispatches to provider adapter.
+- Reconciles usage and emits detect events.
+
+## Admin Plane
+
+- Exposes operational APIs:
+  - health
+  - report summary/top
+  - budgets CRUD-like operations
+  - estimate endpoint
+  - detect status/resume
+  - events SSE stream
+
+## CLI Plane
+
+- Operator interface for setup and inspection:
+  - init, doctor, config
+  - prices show/update
+  - budget list/set/reset
+  - estimate, report summary/top
+  - detect status/resume
+  - tail (SSE consumer)
+
+## Core Flow (Request Lifecycle)
+
+1. Request enters proxy.
+2. Request is attributed (project/session context).
+3. Estimated cost is computed from pricebook.
+4. Ledger reserve executes atomically.
+5. Provider call executes.
+6. Actual usage reconciles back into ledger.
+7. Events are persisted for budget/detect/provider outcomes.
+8. CLI/admin read from the same local database.
+
+## Error and Safety Model
+
+- `guard` mode fails closed on critical budget/ledger lookup failures.
+- `observe` mode logs warnings/failsafe events and allows traffic.
+- budget hard blocks map to structured non-retryable responses.
+- detect pause state can be resumed explicitly by operator command/API.
+
+## Design Constraints (Current Alpha)
+
+- local-first architecture (single-node SQLite default)
+- deterministic local pricebook import path
+- no external control plane dependency required for core operation
+
+For known gaps and temporary alpha limitations, see [LIMITATIONS.md](./LIMITATIONS.md).

--- a/docs/CONFIG-REFERENCE.md
+++ b/docs/CONFIG-REFERENCE.md
@@ -1,0 +1,141 @@
+# PennyPrompt Config Reference (Alpha)
+
+This reference reflects the current runtime behavior in `penny-config`.
+
+## Resolution Order
+
+Config is resolved in this order (later overrides earlier):
+
+1. `config/default.toml`
+2. `presets/<name>.toml` (when `--preset` is used)
+3. user config file (`PENNY_CONFIG` or `~/.config/pennyprompt/config.toml`)
+4. selected `PENNY_*` environment overrides
+
+## User Config Path
+
+- explicit: `PENNY_CONFIG=/absolute/path/config.toml`
+- default: `~/.config/pennyprompt/config.toml`
+
+## Top-Level Sections
+
+- `[server]`
+- `[defaults]`
+- `[attribution]`
+- `[providers.anthropic]`
+- `[providers.openai]`
+- `[[budgets]]` (one or more)
+- `[detect]`
+
+## Section Reference
+
+## `[server]`
+
+- `bind` (`string`): proxy bind address (example `127.0.0.1:8585`)
+- `admin_socket` (`string`): admin socket path
+- `database_path` (`string`): SQLite database path
+- `mode` (`observe|guard`)
+
+## `[defaults]`
+
+- `provider` (`string`): default provider id
+- `model` (`string`): default model id
+
+## `[attribution]`
+
+- `auto_detect_project` (`bool`)
+- `session_window_minutes` (`u32`, must be `> 0`)
+
+## `[providers.<name>]`
+
+- `enabled` (`bool`)
+- `base_url` (`string`, valid URL required when enabled)
+- `api_key_env` (`string`, required when enabled)
+- `api_format` (`string`, required when enabled)
+
+## `[[budgets]]`
+
+- `scope_type` (`global|project|session`)
+- `scope_id` (`string`, non-empty)
+- `window_type` (`day|week|month|total`)
+- `hard_limit_usd` (`number`, optional, must be `> 0`)
+- `soft_limit_usd` (`number`, optional, must be `> 0`)
+- `action_on_hard` (`string`, default `block`)
+- `action_on_soft` (`string`, default `warn`)
+- `preset_source` (`string`, optional)
+
+Validation rule:
+
+- if both are set: `soft_limit_usd <= hard_limit_usd`
+
+## `[detect]`
+
+- `enabled` (`bool`)
+- `burn_rate_alert_usd_per_hour` (`number`)
+- `loop_window_seconds` (`u64`)
+- `loop_threshold_similar_requests` (`u32`)
+- `loop_action` (`alert|pause`)
+
+## Presets
+
+Current preset files:
+
+- `presets/indie.toml`
+- `presets/team.toml`
+- `presets/explore.toml`
+
+Preset budgets are tagged internally with `preset:<name>` when applied.
+
+## Environment Overrides (currently implemented)
+
+- `PENNY_CONFIG`
+- `PENNY_SERVER_BIND`
+- `PENNY_SERVER_MODE` (`observe|guard`)
+- `PENNY_DEFAULTS_PROVIDER`
+- `PENNY_DEFAULTS_MODEL`
+- `PENNY_ATTRIBUTION_AUTO_DETECT_PROJECT` (`true|false|1|0|yes|no|on|off`)
+- `PENNY_ATTRIBUTION_SESSION_WINDOW_MINUTES` (integer)
+
+## Example Minimal Config
+
+```toml
+[server]
+bind = "127.0.0.1:8585"
+admin_socket = "~/.local/share/pennyprompt/admin.sock"
+database_path = "~/.local/share/pennyprompt/penny.db"
+mode = "guard"
+
+[defaults]
+provider = "anthropic"
+model = "claude-sonnet-4-6"
+
+[attribution]
+auto_detect_project = true
+session_window_minutes = 30
+
+[providers.anthropic]
+enabled = true
+base_url = "https://api.anthropic.com"
+api_key_env = "ANTHROPIC_API_KEY"
+api_format = "anthropic"
+
+[providers.openai]
+enabled = true
+base_url = "https://api.openai.com"
+api_key_env = "OPENAI_API_KEY"
+api_format = "openai"
+
+[[budgets]]
+scope_type = "global"
+scope_id = "*"
+window_type = "day"
+hard_limit_usd = 10.0
+action_on_hard = "block"
+action_on_soft = "warn"
+
+[detect]
+enabled = true
+burn_rate_alert_usd_per_hour = 10.0
+loop_window_seconds = 120
+loop_threshold_similar_requests = 8
+loop_action = "pause"
+```

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -1,0 +1,99 @@
+# PennyPrompt Alpha Installation
+
+This document describes the current alpha installation path for this repository.
+
+## 1. Prerequisites
+
+- macOS or Linux shell environment
+- Rust toolchain (stable) with `cargo`
+- SQLite support (already included via `sqlx` + bundled SQLite driver)
+
+Check toolchain:
+
+```bash
+rustc --version
+cargo --version
+```
+
+## 2. Clone and Build
+
+```bash
+git clone https://github.com/manuelpenazuniga/PennyPrompt.git
+cd PennyPrompt
+cargo build --release -p penny-cli
+```
+
+The binary is generated at:
+
+```text
+target/release/penny-cli
+```
+
+## 3. Run Commands
+
+You can either:
+
+- run the binary directly:
+
+```bash
+./target/release/penny-cli doctor
+```
+
+- or run from source:
+
+```bash
+cargo run -p penny-cli -- doctor
+```
+
+Optional convenience alias:
+
+```bash
+alias pp='cargo run -p penny-cli --'
+pp doctor
+```
+
+## 4. Configure Initial Settings
+
+Create a local config from a preset:
+
+```bash
+./target/release/penny-cli init --preset indie
+```
+
+Default config target:
+
+```text
+~/.config/pennyprompt/config.toml
+```
+
+You can override config path with:
+
+```bash
+export PENNY_CONFIG=/absolute/path/to/config.toml
+```
+
+## 5. Seed Pricebook and Verify
+
+```bash
+./target/release/penny-cli prices update
+./target/release/penny-cli doctor
+./target/release/penny-cli config --json
+```
+
+## 6. API Key Environment Variables
+
+Set keys for providers you plan to use:
+
+```bash
+export ANTHROPIC_API_KEY=...
+export OPENAI_API_KEY=...
+```
+
+`doctor` reports whether these keys are present.
+
+## Troubleshooting
+
+- `config already exists`: rerun `init` with `--force`.
+- `HOME not set`: define `HOME` or use `PENNY_CONFIG`.
+- `no active pricebook entries`: run `prices update`.
+- DB connectivity errors: verify `server.database_path` and file permissions.

--- a/docs/LIMITATIONS.md
+++ b/docs/LIMITATIONS.md
@@ -1,0 +1,35 @@
+# Known Limitations (Alpha)
+
+This list documents current constraints as of April 18, 2026.
+
+## CLI / Product Surface
+
+- `serve` lifecycle orchestration is not fully consolidated in `penny-cli` yet.
+- Some outputs are operator-focused and intentionally minimal (not final UX polish).
+
+## Pricebook Update
+
+- `prices update` currently imports from local repository TOML files.
+- There is no remote signed feed sync in the current alpha branch.
+
+## Runtime Topology
+
+- Default setup assumes a local single-node SQLite database.
+- Team/multi-node coordination is out of scope for current alpha.
+
+## API/Control Plane Assumptions
+
+- `tail` and `detect` control commands assume admin API availability (default `http://127.0.0.1:8586` in CLI commands).
+- If admin plane is unavailable, related commands fail as expected.
+
+## Data and Reporting
+
+- Reports reflect local persisted usage only.
+- Empty datasets produce explicit "no rows" style output (expected in fresh installs).
+
+## Roadmap-Tracked Gaps
+
+- Integration/golden release-grade test expansion is tracked in issue `#36`.
+- Release automation and install script/changelog are tracked in issue `#37`.
+
+These limitations are intentional scope boundaries for M6 sequencing.

--- a/docs/PRICEBOOK.md
+++ b/docs/PRICEBOOK.md
@@ -1,0 +1,86 @@
+# Pricebook Guide (Alpha)
+
+PennyPrompt pricing is sourced from local TOML files and imported into SQLite.
+
+## Source Files
+
+- `prices/anthropic.toml`
+- `prices/openai.toml`
+
+These files are version-controlled in this repository.
+
+## Import and Refresh
+
+Import both files into the local database:
+
+```bash
+penny-cli prices update
+```
+
+Show active entries:
+
+```bash
+penny-cli prices show --limit 20
+```
+
+(`cargo run -p penny-cli -- prices update` works too.)
+
+## File Format
+
+Top-level fields:
+
+- `provider_id`
+- `provider_name`
+- `api_format`
+- `source`
+
+Per entry (`[[entries]]`):
+
+- `model_id`
+- `external_name`
+- `display_name`
+- `class`
+- `input_per_mtok`
+- `output_per_mtok`
+- `effective_from`
+- `effective_until` (optional)
+
+Example:
+
+```toml
+provider_id = "anthropic"
+provider_name = "Anthropic"
+api_format = "anthropic"
+source = "local"
+
+[[entries]]
+model_id = "claude-sonnet-4-6"
+external_name = "claude-sonnet-4-6"
+display_name = "Claude Sonnet 4.6"
+class = "balanced"
+input_per_mtok = 3.0
+output_per_mtok = 15.0
+effective_from = "2026-04-10T00:00:00Z"
+```
+
+## Effective-Window Semantics
+
+At runtime, price resolution selects the latest entry where:
+
+- `effective_from <= now`
+- `effective_until IS NULL OR effective_until > now`
+
+This enables non-destructive price evolution over time.
+
+## How to Add/Change a Model
+
+1. Edit the corresponding provider file under `prices/`.
+2. Add a new `[[entries]]` block or update with a new `effective_from`.
+3. Run `penny-cli prices update`.
+4. Verify with `penny-cli prices show`.
+5. Run tests for pricing-sensitive components.
+
+## Notes
+
+- This alpha flow is local-file based; no remote fetch is required.
+- Estimation/reporting reproducibility depends on imported snapshot state.

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -1,0 +1,110 @@
+# PennyPrompt Quickstart (Alpha)
+
+Goal: get from zero to actionable local operator output in about 5-10 minutes.
+
+## 1. Build the CLI
+
+```bash
+git clone https://github.com/manuelpenazuniga/PennyPrompt.git
+cd PennyPrompt
+cargo build --release -p penny-cli
+```
+
+Use one of these command styles in the rest of this guide:
+
+- `./target/release/penny-cli <command>`
+- `cargo run -p penny-cli -- <command>`
+
+## 2. Initialize Configuration
+
+```bash
+./target/release/penny-cli init --preset indie
+```
+
+Available presets:
+
+- `indie`
+- `team`
+- `explore`
+
+If the file already exists and you want to overwrite:
+
+```bash
+./target/release/penny-cli init --preset indie --force
+```
+
+## 3. Set Provider Keys
+
+```bash
+export ANTHROPIC_API_KEY=...
+export OPENAI_API_KEY=...
+```
+
+## 4. Import Local Pricebook
+
+```bash
+./target/release/penny-cli prices update
+./target/release/penny-cli prices show --limit 20
+```
+
+## 5. Run Health and Config Checks
+
+```bash
+./target/release/penny-cli doctor
+./target/release/penny-cli config --json
+```
+
+## 6. Try Core Operator Commands
+
+Estimate:
+
+```bash
+./target/release/penny-cli estimate \
+  --model claude-sonnet-4-6 \
+  --context-files "src/**/*.rs" \
+  --task-type multi-round
+```
+
+Budget overview:
+
+```bash
+./target/release/penny-cli budget list
+```
+
+Detect control plane:
+
+```bash
+./target/release/penny-cli detect status
+```
+
+Reports:
+
+```bash
+./target/release/penny-cli report summary --since 1d
+./target/release/penny-cli report top --limit 20
+```
+
+## 7. Optional Live Monitoring (if admin plane is running)
+
+```bash
+./target/release/penny-cli tail --admin-url http://127.0.0.1:8586
+```
+
+Resume a paused session:
+
+```bash
+./target/release/penny-cli detect resume <session_id>
+```
+
+## Expected First Outcomes
+
+- `doctor` shows config and DB status.
+- `prices show` lists active models and rates.
+- `estimate` returns min/max range and budget impact.
+- `report` commands return either data or explicit "no usage rows" output.
+
+If something is unclear, continue in:
+
+- [INSTALL.md](./INSTALL.md)
+- [CONFIG-REFERENCE.md](./CONFIG-REFERENCE.md)
+- [LIMITATIONS.md](./LIMITATIONS.md)


### PR DESCRIPTION
## Summary
- add complete alpha docs set:
  - `docs/INSTALL.md`
  - `docs/QUICKSTART.md`
  - `docs/CONFIG-REFERENCE.md`
  - `docs/ARCHITECTURE.md`
  - `docs/PRICEBOOK.md`
  - `docs/LIMITATIONS.md`
- update README with docs index and fix spec link path

## Validation
- cargo test -p penny-cli

Closes #35
