### PR TITLE
feat(release): add multi-target release workflow, installer, and changelog (#37)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,100 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    name: Build ${{ matrix.target }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-24.04
+            target: x86_64-unknown-linux-gnu
+          - os: ubuntu-24.04-arm
+            target: aarch64-unknown-linux-gnu
+          - os: macos-13
+            target: x86_64-apple-darwin
+          - os: macos-14
+            target: aarch64-apple-darwin
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+
+      - name: Cache cargo and target
+        uses: Swatinem/rust-cache@v2
+
+      - name: Build release binary
+        run: cargo build --release -p penny-cli --target "${{ matrix.target }}" --locked
+
+      - name: Package release artifact and checksum
+        shell: bash
+        run: |
+          set -euo pipefail
+          VERSION="${GITHUB_REF_NAME}"
+          TARGET="${{ matrix.target }}"
+          ASSET="penny-cli-${VERSION}-${TARGET}"
+          mkdir -p dist
+          cp "target/${TARGET}/release/penny-cli" "dist/penny-cli"
+          tar -C dist -czf "dist/${ASSET}.tar.gz" penny-cli
+          (
+            cd dist
+            if command -v shasum >/dev/null 2>&1; then
+              shasum -a 256 "${ASSET}.tar.gz" > "${ASSET}.sha256"
+            else
+              sha256sum "${ASSET}.tar.gz" > "${ASSET}.sha256"
+            fi
+          )
+          rm -f dist/penny-cli
+
+      - name: Upload artifact bundle
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-${{ matrix.target }}
+          if-no-files-found: error
+          path: |
+            dist/*.tar.gz
+            dist/*.sha256
+
+  publish:
+    name: Publish release
+    runs-on: ubuntu-24.04
+    needs: build
+    steps:
+      - name: Download all release artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: release-*
+          merge-multiple: true
+          path: dist
+
+      - name: Build aggregated checksum file
+        shell: bash
+        run: |
+          set -euo pipefail
+          cd dist
+          cat *.sha256 > CHECKSUMS.txt
+
+      - name: Create GitHub release
+        uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true
+          prerelease: true
+          files: |
+            dist/*.tar.gz
+            dist/*.sha256
+            dist/CHECKSUMS.txt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,20 @@
+# Changelog
+
+All notable changes to PennyPrompt are documented in this file.
+
+The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+
+## [Unreleased]
+
+### Added
+- Upcoming changes are tracked via issue-first workflow and merged through PRs.
+
+## [v0.1.0-alpha.1] - 2026-04-18
+
+### Added
+- Core M1-M5 foundation: config loading, store/migrations, pricing engine, proxy plane, atomic budget/ledger flow, detect heuristics, and operator CLI commands.
+- M6 docs set: install, quickstart, config reference, architecture, pricebook, and limitations.
+- Integration and golden coverage for admin, proxy, ledger, and CLI event formatting.
+- Release automation workflow for macOS/Linux on x86_64 and arm64 with per-artifact SHA-256 checksums.
+- `scripts/install.sh` bootstrap installer for `curl | sh` installs from GitHub Releases.
+

--- a/README.md
+++ b/README.md
@@ -399,6 +399,8 @@ Alpha documentation set:
 - [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md)
 - [docs/PRICEBOOK.md](docs/PRICEBOOK.md)
 - [docs/LIMITATIONS.md](docs/LIMITATIONS.md)
+- [docs/RELEASE.md](docs/RELEASE.md)
+- [CHANGELOG.md](CHANGELOG.md)
 
 ## License
 

--- a/docs/ALPHA-MANUAL-CHECKLIST.md
+++ b/docs/ALPHA-MANUAL-CHECKLIST.md
@@ -67,6 +67,14 @@ Use this checklist before cutting an alpha release candidate.
 - [ ] `docs/ARCHITECTURE.md` matches current crate boundaries.
 - [ ] `docs/PRICEBOOK.md` matches current import/update flow.
 - [ ] `docs/LIMITATIONS.md` reflects known alpha constraints.
+- [ ] `docs/RELEASE.md` reflects current release workflow.
+- [ ] `CHANGELOG.md` updated for the target tag.
+
+## Release Artifacts
+
+- [ ] Tag pushed as `v*` and `Release` workflow finished.
+- [ ] Artifacts published for 4 targets (Linux/macOS on x86_64 + arm64).
+- [ ] SHA-256 checksum files published and verified.
 
 ## Release Readiness Decision
 

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -1,12 +1,40 @@
 # PennyPrompt Alpha Installation
 
-This document describes the current alpha installation path for this repository.
+This document describes alpha installation paths for PennyPrompt.
 
 ## 1. Prerequisites
 
 - macOS or Linux shell environment
-- Rust toolchain (stable) with `cargo`
-- SQLite support (already included via `sqlx` + bundled SQLite driver)
+- `curl`, `tar`, and `shasum` or `sha256sum`
+- Rust toolchain (stable) with `cargo` (only required for source builds)
+
+## 2. Quick Install from GitHub Release (`curl | sh`)
+
+Install latest alpha release:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/manuelpenazuniga/PennyPrompt/main/scripts/install.sh | sh
+```
+
+Install specific version:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/manuelpenazuniga/PennyPrompt/main/scripts/install.sh | PENNY_VERSION=v0.1.0-alpha.1 sh
+```
+
+By default the binary is installed to:
+
+```text
+~/.local/bin/penny-cli
+```
+
+Override install location:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/manuelpenazuniga/PennyPrompt/main/scripts/install.sh | PENNY_INSTALL_DIR=/usr/local/bin sh
+```
+
+## 3. Build from Source (Alternative)
 
 Check toolchain:
 
@@ -15,7 +43,7 @@ rustc --version
 cargo --version
 ```
 
-## 2. Clone and Build
+Clone and build:
 
 ```bash
 git clone https://github.com/manuelpenazuniga/PennyPrompt.git
@@ -29,7 +57,7 @@ The binary is generated at:
 target/release/penny-cli
 ```
 
-## 3. Run Commands
+## 4. Run Commands
 
 You can either:
 
@@ -52,7 +80,7 @@ alias pp='cargo run -p penny-cli --'
 pp doctor
 ```
 
-## 4. Configure Initial Settings
+## 5. Configure Initial Settings
 
 Create a local config from a preset:
 
@@ -72,7 +100,7 @@ You can override config path with:
 export PENNY_CONFIG=/absolute/path/to/config.toml
 ```
 
-## 5. Seed Pricebook and Verify
+## 6. Seed Pricebook and Verify
 
 ```bash
 ./target/release/penny-cli prices update
@@ -80,7 +108,7 @@ export PENNY_CONFIG=/absolute/path/to/config.toml
 ./target/release/penny-cli config --json
 ```
 
-## 6. API Key Environment Variables
+## 7. API Key Environment Variables
 
 Set keys for providers you plan to use:
 
@@ -97,3 +125,4 @@ export OPENAI_API_KEY=...
 - `HOME not set`: define `HOME` or use `PENNY_CONFIG`.
 - `no active pricebook entries`: run `prices update`.
 - DB connectivity errors: verify `server.database_path` and file permissions.
+- `unsupported OS/architecture`: install script currently supports Linux/macOS on x86_64 and arm64.

--- a/docs/LIMITATIONS.md
+++ b/docs/LIMITATIONS.md
@@ -27,9 +27,4 @@ This list documents current constraints as of April 18, 2026.
 - Reports reflect local persisted usage only.
 - Empty datasets produce explicit "no rows" style output (expected in fresh installs).
 
-## Roadmap-Tracked Gaps
-
-- Integration/golden release-grade test expansion is tracked in issue `#36`.
-- Release automation and install script/changelog are tracked in issue `#37`.
-
-These limitations are intentional scope boundaries for M6 sequencing.
+These limitations are intentional scope boundaries for current alpha sequencing.

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -1,0 +1,84 @@
+# Release Process (Alpha)
+
+This document defines the repeatable process for alpha releases.
+
+## Scope
+
+Current release automation builds and publishes `penny-cli` binaries for:
+
+- Linux `x86_64-unknown-linux-gnu`
+- Linux `aarch64-unknown-linux-gnu`
+- macOS `x86_64-apple-darwin`
+- macOS `aarch64-apple-darwin`
+
+All artifacts are published as `.tar.gz` plus SHA-256 checksums.
+
+## Workflow Trigger
+
+Release workflow file:
+
+```text
+.github/workflows/release.yml
+```
+
+Trigger condition:
+
+- push a tag that starts with `v` (example: `v0.1.0-alpha.1`)
+
+Manual trigger is also available via `workflow_dispatch`.
+
+## Cut a Release
+
+1. Ensure `main` is green and synchronized.
+2. Update `CHANGELOG.md`.
+3. Create and push a tag:
+
+```bash
+git switch main
+git pull --ff-only origin main
+git tag v0.1.0-alpha.1
+git push origin v0.1.0-alpha.1
+```
+
+4. Wait for the `Release` workflow to finish.
+5. Verify GitHub Release contains:
+- 4 target archives (`penny-cli-vX.Y.Z-<target>.tar.gz`)
+- 4 checksum files (`.sha256`)
+- `CHECKSUMS.txt`
+
+## Artifact Verification
+
+Download one artifact and verify:
+
+```bash
+shasum -a 256 -c penny-cli-v0.1.0-alpha.1-x86_64-unknown-linux-gnu.sha256
+```
+
+If `shasum` is unavailable, use `sha256sum -c`.
+
+## Installer Path
+
+Installer script:
+
+```text
+scripts/install.sh
+```
+
+Supported env vars:
+
+- `PENNY_VERSION` (example: `v0.1.0-alpha.1`)
+- `PENNY_INSTALL_DIR` (default: `~/.local/bin`)
+- `PENNY_REPO` (default: `manuelpenazuniga/PennyPrompt`)
+
+Usage:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/manuelpenazuniga/PennyPrompt/main/scripts/install.sh | sh
+```
+
+Pinned version:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/manuelpenazuniga/PennyPrompt/main/scripts/install.sh | PENNY_VERSION=v0.1.0-alpha.1 sh
+```
+

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,113 @@
+#!/bin/sh
+set -eu
+
+REPO="${PENNY_REPO:-manuelpenazuniga/PennyPrompt}"
+INSTALL_DIR="${PENNY_INSTALL_DIR:-${HOME:-$PWD}/.local/bin}"
+BIN_NAME="penny-cli"
+
+need_cmd() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "error: required command not found: $1" >&2
+    exit 1
+  fi
+}
+
+detect_os() {
+  uname_s="$(uname -s)"
+  case "$uname_s" in
+    Linux) echo "unknown-linux-gnu" ;;
+    Darwin) echo "apple-darwin" ;;
+    *)
+      echo "error: unsupported OS: $uname_s" >&2
+      exit 1
+      ;;
+  esac
+}
+
+detect_arch() {
+  uname_m="$(uname -m)"
+  case "$uname_m" in
+    x86_64|amd64) echo "x86_64" ;;
+    arm64|aarch64) echo "aarch64" ;;
+    *)
+      echo "error: unsupported architecture: $uname_m" >&2
+      exit 1
+      ;;
+  esac
+}
+
+resolve_version() {
+  if [ -n "${PENNY_VERSION:-}" ]; then
+    echo "$PENNY_VERSION"
+    return
+  fi
+
+  latest_json="$(curl -fsSL "https://api.github.com/repos/${REPO}/releases/latest")"
+  version="$(echo "$latest_json" | sed -n 's/.*"tag_name":[[:space:]]*"\([^"]*\)".*/\1/p' | head -n 1)"
+  if [ -z "$version" ]; then
+    echo "error: unable to resolve latest release tag from GitHub API" >&2
+    exit 1
+  fi
+  echo "$version"
+}
+
+verify_checksum() {
+  checksum_file="$1"
+  if command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 -c "$checksum_file"
+    return
+  fi
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum -c "$checksum_file"
+    return
+  fi
+  echo "error: need shasum or sha256sum to verify checksums" >&2
+  exit 1
+}
+
+main() {
+  need_cmd curl
+  need_cmd tar
+  need_cmd mktemp
+
+  os="$(detect_os)"
+  arch="$(detect_arch)"
+  target="${arch}-${os}"
+  version="$(resolve_version)"
+
+  asset="${BIN_NAME}-${version}-${target}.tar.gz"
+  checksum="${BIN_NAME}-${version}-${target}.sha256"
+  base_url="https://github.com/${REPO}/releases/download/${version}"
+
+  tmp_dir="$(mktemp -d)"
+  trap 'rm -rf "$tmp_dir"' EXIT INT TERM
+
+  echo "Installing ${BIN_NAME} ${version} for ${target}"
+  curl -fsSL "${base_url}/${asset}" -o "${tmp_dir}/${asset}"
+  curl -fsSL "${base_url}/${checksum}" -o "${tmp_dir}/${checksum}"
+
+  (
+    cd "$tmp_dir"
+    verify_checksum "$checksum"
+    tar -xzf "$asset"
+  )
+
+  mkdir -p "$INSTALL_DIR"
+  if command -v install >/dev/null 2>&1; then
+    install -m 755 "${tmp_dir}/${BIN_NAME}" "${INSTALL_DIR}/${BIN_NAME}"
+  else
+    cp "${tmp_dir}/${BIN_NAME}" "${INSTALL_DIR}/${BIN_NAME}"
+    chmod 755 "${INSTALL_DIR}/${BIN_NAME}"
+  fi
+
+  echo "Installed to ${INSTALL_DIR}/${BIN_NAME}"
+  case ":$PATH:" in
+    *":${INSTALL_DIR}:"*) ;;
+    *)
+      echo "warning: ${INSTALL_DIR} is not in PATH. Add this line to your shell profile:"
+      echo "  export PATH=\"${INSTALL_DIR}:\$PATH\""
+      ;;
+  esac
+}
+
+main "$@"


### PR DESCRIPTION
## Summary
Implements M6 issue #37 under EPIC #33 by adding release automation, install bootstrap, checksums, and changelog/release documentation.

## What changed
- Added `.github/workflows/release.yml`:
  - triggers on `v*` tags
  - builds `penny-cli` for Linux/macOS on x86_64 and arm64
  - packages `.tar.gz` artifacts
  - generates per-artifact `.sha256` files and aggregated `CHECKSUMS.txt`
  - publishes GitHub Release assets
- Added `scripts/install.sh` for `curl | sh` installs with:
  - OS/arch detection
  - latest or pinned version install
  - checksum verification before install
- Added `CHANGELOG.md` initial alpha entry.
- Added `docs/RELEASE.md` with repeatable release/tagging process.
- Updated install/checklist/limitations/readme docs to reflect release flow.

## Validation
- `cargo check --workspace --locked`
- `cargo test -p penny-cli`
- `sh -n scripts/install.sh`

Closes #37
