### PR TITLE
docs(tech-note): track non-blocking Gemini recommendations and align install prereqs (#94)

### DIFF
--- a/crates/penny-admin/src/lib.rs
+++ b/crates/penny-admin/src/lib.rs
@@ -385,6 +385,8 @@ async fn get_report_summary(
         ReportSummaryBy::Model => ("requests.model_used", ""),
         ReportSummaryBy::Session => ("COALESCE(requests.session_id, '(none)')", ""),
     };
+    // SQL fragments below are selected from trusted enum variants only.
+    // All user-provided filters stay parameterized through bind placeholders.
 
     let grouped_sql = format!(
         r#"

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -5,7 +5,7 @@ This document describes alpha installation paths for PennyPrompt.
 ## 1. Prerequisites
 
 - macOS or Linux shell environment
-- `curl`, `tar`, and `shasum` or `sha256sum`
+- `curl`, `tar`, `mktemp`, and `shasum` or `sha256sum`
 - Rust toolchain (stable) with `cargo` (only required for source builds)
 
 ## 2. Quick Install from GitHub Release (`curl | sh`)

--- a/docs/TECHNICAL_NOTES.md
+++ b/docs/TECHNICAL_NOTES.md
@@ -1,0 +1,44 @@
+# PennyPrompt Technical Notes
+
+This file tracks non-blocking technical recommendations that should remain visible
+without stopping milestone delivery.
+
+## 2026-04: Gemini Non-Blocking Recommendations (`#94`)
+
+Source reviews:
+- PR #70
+- PR #82
+- PR #84
+
+### 1. Docs heading hierarchy
+
+Status: tracked, low priority.
+
+Decision:
+- Keep incremental cleanup as docs are touched by future functional work.
+- Do not open a dedicated refactor pass unless readability regressions appear.
+
+### 2. Installer prerequisites consistency
+
+Status: addressed in this issue.
+
+Decision:
+- Keep install docs aligned with actual installer script dependencies.
+- `mktemp` is now listed in `docs/INSTALL.md` prerequisites.
+
+### 3. Dynamic SQL construction style
+
+Status: tracked with guardrails in place.
+
+Decision:
+- Current dynamic SQL interpolation is constrained to trusted enum-controlled
+  fragments (group key and join variant), not raw user input.
+- Query parameters remain bound (`?` placeholders) for all external filters.
+- If summary query complexity grows, migrate to a query-builder style in a future
+  dedicated hardening issue.
+
+### Close Criteria for `#94`
+
+- This recommendation set remains documented and discoverable.
+- Blocking risks are not present in current implementation scope.
+- Future hardening can be tracked independently without stalling roadmap flow.


### PR DESCRIPTION
## Summary
- Add a technical note to track non-blocking Gemini recommendations and closure criteria.
- Align install prerequisites with the actual installer dependency list (`mktemp`).
- Document trust boundaries in admin summary dynamic SQL (enum-controlled fragments + bound params).

## Validation
- cargo fmt --all
- cargo check --workspace --locked

Closes #94
