### PR TITLE
fix(admin): formalize detect resume best-effort consistency contract (#110)

### DIFF
--- a/crates/penny-admin/src/lib.rs
+++ b/crates/penny-admin/src/lib.rs
@@ -218,6 +218,30 @@ struct DetectResumePayload {
 }
 
 #[derive(Debug, Serialize)]
+struct DetectResumeResponse {
+    resumed: bool,
+    session_id: String,
+    event: penny_detect::DetectEventRecord,
+    persisted: bool,
+    consistency: DetectResumeConsistency,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    warning: Option<DetectResumeWarning>,
+}
+
+#[derive(Debug, Serialize)]
+struct DetectResumeConsistency {
+    mode: &'static str,
+    event_persistence_guarantee: &'static str,
+    event_persisted: bool,
+}
+
+#[derive(Debug, Serialize)]
+struct DetectResumeWarning {
+    code: &'static str,
+    message: String,
+}
+
+#[derive(Debug, Serialize)]
 struct AdminHealth {
     status: &'static str,
     uptime_seconds: u64,
@@ -795,6 +819,9 @@ async fn post_detect_resume(
         );
     };
 
+    // Consistency policy: best-effort persistence.
+    // The resume action is applied in-memory first to unblock the session; event persistence
+    // is attempted afterwards and reported explicitly in the response contract.
     let mut persisted = true;
     if let Err(error) = EventRepo::insert(
         &state.store,
@@ -812,12 +839,23 @@ async fn post_detect_resume(
         log_internal_error("detect_resume_persist_failed", error.to_string());
     }
 
-    Json(json!({
-        "resumed": true,
-        "session_id": session_id,
-        "event": event,
-        "persisted": persisted
-    }))
+    let warning = (!persisted).then(|| DetectResumeWarning {
+        code: "detect_resume_event_not_persisted",
+        message: "session resumed in-memory but resume event could not be persisted".to_string(),
+    });
+
+    Json(DetectResumeResponse {
+        resumed: true,
+        session_id: session_id.to_string(),
+        event,
+        persisted,
+        consistency: DetectResumeConsistency {
+            mode: "best_effort_resume_then_persist",
+            event_persistence_guarantee: "best_effort",
+            event_persisted: persisted,
+        },
+        warning,
+    })
     .into_response()
 }
 
@@ -1647,6 +1685,16 @@ mod tests {
         assert_eq!(resume_json["resumed"], true);
         assert_eq!(resume_json["session_id"], "sess-detect-b");
         assert_eq!(resume_json["persisted"], true);
+        assert_eq!(
+            resume_json["consistency"]["mode"],
+            "best_effort_resume_then_persist"
+        );
+        assert_eq!(
+            resume_json["consistency"]["event_persistence_guarantee"],
+            "best_effort"
+        );
+        assert_eq!(resume_json["consistency"]["event_persisted"], true);
+        assert!(resume_json["warning"].is_null());
 
         let status_response = app
             .oneshot(
@@ -1675,6 +1723,77 @@ mod tests {
         .await
         .expect("event rows");
         assert!(rows.iter().any(|row| row == "session_resumed"));
+    }
+
+    #[tokio::test]
+    async fn detect_resume_reports_partial_success_when_event_persistence_fails() {
+        let store = setup_store().await;
+        let detector = detector_with_paused_session("sess-detect-c");
+        let app = build_router(AdminState::new(store.clone()).with_detector(detector));
+
+        sqlx::query("DROP TABLE events")
+            .execute(store.pool())
+            .await
+            .expect("drop events table");
+
+        let resume_response = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/admin/detect/resume")
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(
+                        json!({
+                            "session_id": "sess-detect-c",
+                            "request_id": "req-resume-cli"
+                        })
+                        .to_string(),
+                    ))
+                    .expect("build request"),
+            )
+            .await
+            .expect("response");
+
+        assert_eq!(resume_response.status(), StatusCode::OK);
+        let body = to_bytes(resume_response.into_body(), usize::MAX)
+            .await
+            .expect("read body");
+        let resume_json: Value = serde_json::from_slice(&body).expect("resume json");
+        assert_eq!(resume_json["resumed"], true);
+        assert_eq!(resume_json["persisted"], false);
+        assert_eq!(
+            resume_json["consistency"]["mode"],
+            "best_effort_resume_then_persist"
+        );
+        assert_eq!(resume_json["consistency"]["event_persisted"], false);
+        assert_eq!(
+            resume_json["warning"]["code"],
+            "detect_resume_event_not_persisted"
+        );
+        assert!(resume_json["warning"]["message"]
+            .as_str()
+            .expect("warning message")
+            .contains("resumed in-memory"));
+
+        let status_response = app
+            .oneshot(
+                Request::builder()
+                    .method("GET")
+                    .uri("/admin/detect/status")
+                    .body(Body::empty())
+                    .expect("build request"),
+            )
+            .await
+            .expect("response");
+        let body = to_bytes(status_response.into_body(), usize::MAX)
+            .await
+            .expect("read body");
+        let status_json: Value = serde_json::from_slice(&body).expect("status json");
+        assert!(status_json["paused_sessions"]
+            .as_array()
+            .expect("array")
+            .is_empty());
     }
 
     #[tokio::test]

--- a/crates/penny-cli/src/main.rs
+++ b/crates/penny-cli/src/main.rs
@@ -1286,12 +1286,24 @@ async fn run_detect_resume(
         .get("resumed")
         .and_then(Value::as_bool)
         .unwrap_or(false);
+    let persisted = parsed
+        .get("persisted")
+        .and_then(Value::as_bool)
+        .unwrap_or(true);
     if resumed {
         println!(
             "Detect resume succeeded: session={} request_id={}",
             session_id,
             request_id.unwrap_or("(none)")
         );
+        if !persisted {
+            let warning = parsed
+                .get("warning")
+                .and_then(|value| value.get("message"))
+                .and_then(Value::as_str)
+                .unwrap_or("resume event persistence failed");
+            println!("  warning: {warning}");
+        }
     } else {
         println!("Detect resume response: {parsed}");
     }

--- a/docs/TECHNICAL_NOTES.md
+++ b/docs/TECHNICAL_NOTES.md
@@ -42,3 +42,21 @@ Decision:
 - This recommendation set remains documented and discoverable.
 - Blocking risks are not present in current implementation scope.
 - Future hardening can be tracked independently without stalling roadmap flow.
+
+## 2026-04: Detect Resume Consistency Policy (`#110`)
+
+Context:
+- Gemini review on PR #97 flagged ambiguity in resume semantics when event
+  persistence fails.
+
+Selected policy:
+- `detect resume` is **best-effort persist after in-memory resume**.
+- We prioritize unblocking the paused session in-memory first.
+- Event persistence is attempted immediately after and reported explicitly.
+
+API contract:
+- `resumed: true` means the in-memory pause state was cleared.
+- `persisted` indicates whether the `session_resumed` event was written.
+- `consistency.mode = best_effort_resume_then_persist`
+- `consistency.event_persistence_guarantee = best_effort`
+- `warning` is present when persistence fails.


### PR DESCRIPTION
## Summary
- Formalize detect-resume consistency as `best_effort_resume_then_persist`.
- Keep in-memory resume as primary action; report persistence status explicitly.
- Extend `/admin/detect/resume` response with:
  - `persisted`
  - `consistency` (mode, guarantee, event_persisted)
  - `warning` when persistence fails
- Update CLI detect-resume output to surface persistence warnings.
- Add tests for:
  - successful resume with persisted event
  - partial-success resume when event persistence fails

## Validation
- cargo fmt --all
- cargo test -p penny-admin
- cargo test -p penny-cli
- cargo check --workspace --locked
- cargo clippy --workspace --all-targets --locked -- -D warnings

Closes #110
