### PR TITLE
fix(ledger): support SQLite extended lock codes in concurrency retry helper (#111)

### DIFF
--- a/crates/penny-ledger/tests/ledger_concurrency_stress.rs
+++ b/crates/penny-ledger/tests/ledger_concurrency_stress.rs
@@ -46,9 +46,17 @@ fn is_sqlite_lock(err: &LedgerError) -> bool {
         LedgerError::Sqlx(inner) => inner
             .as_database_error()
             .and_then(|db_err| db_err.code())
-            .is_some_and(|code| code == "5" || code == "6"),
+            .is_some_and(|code| is_sqlite_lock_code(code.as_ref())),
         _ => false,
     }
+}
+
+fn sqlite_primary_code(code: &str) -> Option<i32> {
+    code.parse::<i32>().ok().map(|raw| raw & 0xFF)
+}
+
+fn is_sqlite_lock_code(code: &str) -> bool {
+    matches!(sqlite_primary_code(code), Some(5 | 6))
 }
 
 async fn reserve_with_retry(
@@ -266,5 +274,33 @@ async fn mixed_concurrent_reserve_and_release_preserves_running_total_invariants
     assert!(
         max_total <= hard_limit.micros(),
         "running total must stay within hard limit"
+    );
+}
+
+#[test]
+fn sqlite_lock_code_classification_handles_primary_and_extended_values() {
+    assert!(
+        is_sqlite_lock_code("5"),
+        "SQLITE_BUSY should be treated as lock"
+    );
+    assert!(
+        is_sqlite_lock_code("6"),
+        "SQLITE_LOCKED should be treated as lock"
+    );
+    assert!(
+        is_sqlite_lock_code("261"),
+        "SQLITE_BUSY_RECOVERY should map to SQLITE_BUSY primary code"
+    );
+    assert!(
+        is_sqlite_lock_code("262"),
+        "SQLITE_LOCKED_SHAREDCACHE should map to SQLITE_LOCKED primary code"
+    );
+    assert!(
+        !is_sqlite_lock_code("2067"),
+        "UNIQUE constraint code must not be treated as lock"
+    );
+    assert!(
+        !is_sqlite_lock_code("not-a-number"),
+        "non numeric codes are not SQLite lock codes"
     );
 }


### PR DESCRIPTION
## Summary
- harden SQLite lock classification in ledger concurrency stress tests
- derive SQLite primary error code from raw/extended codes (`code & 0xFF`)
- treat primary `SQLITE_BUSY (5)` and `SQLITE_LOCKED (6)` as retryable lock conditions
- add unit coverage for representative primary/extended/non-lock variants

## Validation
- cargo fmt --all
- cargo test -p penny-ledger --test ledger_concurrency_stress
- cargo check --workspace --locked
- cargo clippy --workspace --all-targets --locked -- -D warnings

Closes #111
