### PR TITLE
chore(techdebt): apply provider/admin/cli polish batch (#112)

### DIFF
--- a/crates/penny-admin/src/lib.rs
+++ b/crates/penny-admin/src/lib.rs
@@ -514,10 +514,10 @@ async fn get_report_summary(
         }
     };
     let totals = SummaryTotals {
-        request_count: totals_row.get("request_count"),
-        input_tokens: totals_row.get("input_tokens"),
-        output_tokens: totals_row.get("output_tokens"),
-        cost_usd: Money::from_micros(totals_row.get("total_cost_micros")),
+        request_count: totals_row.get::<i64, _>("request_count"),
+        input_tokens: totals_row.get::<i64, _>("input_tokens"),
+        output_tokens: totals_row.get::<i64, _>("output_tokens"),
+        cost_usd: Money::from_micros(totals_row.get::<i64, _>("total_cost_micros")),
     };
     let total_groups = totals_row.get::<i64, _>("total_groups");
     let returned_groups = summary_rows.len() as i64;

--- a/crates/penny-cli/src/main.rs
+++ b/crates/penny-cli/src/main.rs
@@ -1,4 +1,5 @@
 use std::{
+    borrow::Cow,
     collections::{BTreeSet, HashMap},
     fs,
     path::{Path, PathBuf},
@@ -508,6 +509,8 @@ enum CliError {
     Run(String),
     #[error("init error: {0}")]
     Init(String),
+    #[error("render error: {0}")]
+    Render(String),
 }
 
 #[tokio::main]
@@ -2271,7 +2274,7 @@ fn render_summary_json(rows: &[SummaryRow]) -> Result<String, CliError> {
         })
         .collect::<Vec<_>>();
     serde_json::to_string_pretty(&payload)
-        .map_err(|error| CliError::Store(format!("failed to render summary json: {error}")))
+        .map_err(|error| CliError::Render(format!("failed to render summary json: {error}")))
 }
 
 fn render_summary_csv(rows: &[SummaryRow]) -> String {
@@ -2290,12 +2293,12 @@ fn render_summary_csv(rows: &[SummaryRow]) -> String {
     lines.join("\n")
 }
 
-fn csv_escape(value: &str) -> String {
+fn csv_escape(value: &str) -> Cow<'_, str> {
     if value.contains(',') || value.contains('"') || value.contains('\n') || value.contains('\r') {
         let escaped = value.replace('"', "\"\"");
-        format!("\"{escaped}\"")
+        Cow::Owned(format!("\"{escaped}\""))
     } else {
-        value.to_string()
+        Cow::Borrowed(value)
     }
 }
 

--- a/crates/penny-providers/src/lib.rs
+++ b/crates/penny-providers/src/lib.rs
@@ -928,9 +928,8 @@ fn find_sse_delimiter(buffer: &[u8]) -> Option<(usize, usize)> {
 fn drain_sse_events(buffer: &mut Vec<u8>) -> Vec<String> {
     let mut events = Vec::new();
     while let Some((idx, delimiter_len)) = find_sse_delimiter(buffer) {
-        let raw = buffer.drain(..idx).collect::<Vec<u8>>();
-        buffer.drain(..delimiter_len);
-        let raw = String::from_utf8_lossy(&raw).into_owned();
+        let raw = String::from_utf8_lossy(&buffer[..idx]).into_owned();
+        buffer.drain(..(idx + delimiter_len));
         if raw.trim().is_empty() {
             continue;
         }


### PR DESCRIPTION
## Summary
- optimize SSE event draining by removing an intermediate byte-buffer allocation
- make admin report summary totals extraction explicitly typed via `row.get::<i64, _>(...)`
- improve CLI summary rendering:
  - use `CliError::Render` for JSON render failures
  - reduce `csv_escape` allocations using `Cow<'_, str>`

## Validation
- cargo fmt --all
- cargo test --workspace --locked
- cargo check --workspace --locked
- cargo clippy --workspace --all-targets --locked -- -D warnings

Closes #112
