### PR TITLE
feat(cli): implement serve command with proxy/admin lifecycle and graceful shutdown (#129)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1361,8 +1361,12 @@ dependencies = [
  "clap",
  "comfy-table",
  "glob",
+ "penny-admin",
  "penny-config",
  "penny-cost",
+ "penny-detect",
+ "penny-providers",
+ "penny-proxy",
  "penny-store",
  "penny-types",
  "reqwest",
@@ -2022,6 +2026,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "signal-hook-registry"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
+dependencies = [
+ "errno",
+ "libc",
+]
+
+[[package]]
 name = "signature"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2437,6 +2451,7 @@ dependencies = [
  "libc",
  "mio",
  "pin-project-lite",
+ "signal-hook-registry",
  "socket2",
  "tokio-macros",
  "windows-sys 0.61.2",

--- a/README.md
+++ b/README.md
@@ -257,6 +257,14 @@ PENNY_SERVER_BIND=0.0.0.0:8585
 PENNY_DEFAULTS_MODEL=claude-opus-4-6
 ```
 
+`pennyprompt serve` bind behavior:
+
+- Proxy plane binds to `server.bind` (default `127.0.0.1:8585`).
+- Admin plane reads `server.admin_socket`.
+- If `admin_socket` is `host:port`, admin binds TCP.
+- Otherwise admin binds a Unix socket path (supports `~` expansion).
+- You can override at runtime with `--proxy-bind` and `--admin-bind`.
+
 ### Pricebook
 
 Pricing is stored locally in versioned TOML files (`prices/anthropic.toml`, `prices/openai.toml`). No scraping. No external API calls. Works offline.
@@ -271,7 +279,7 @@ pennyprompt prices update          # Download latest from PennyPrompt repo
 ```
 pennyprompt
 ├── init [--preset indie|team|explore]     Setup wizard
-├── serve [--daemon]                        Start proxy + admin
+├── serve [--mock] [--proxy-bind] [--admin-bind]  Start proxy + admin
 ├── estimate [--model M] [--context-files]  Pre-execution cost estimate
 ├── report
 │   ├── summary [--since] [--by project|model|session]

--- a/crates/penny-admin/Cargo.toml
+++ b/crates/penny-admin/Cargo.toml
@@ -16,7 +16,7 @@ penny-types = { path = "../penny-types" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 sqlx = { version = "0.8", features = ["runtime-tokio-rustls", "sqlite"] }
-tokio = { version = "1", features = ["time"] }
+tokio = { version = "1", features = ["net", "time"] }
 tracing = "0.1"
 thiserror = "2"
 

--- a/crates/penny-admin/src/lib.rs
+++ b/crates/penny-admin/src/lib.rs
@@ -3,7 +3,9 @@
 use std::{
     collections::HashMap,
     convert::Infallible,
+    future::Future,
     net::SocketAddr,
+    path::{Path, PathBuf},
     sync::Arc,
     time::{Duration, Instant},
 };
@@ -79,6 +81,8 @@ pub enum AdminError {
     AddressParse(#[from] std::net::AddrParseError),
     #[error("io error: {0}")]
     Io(#[from] std::io::Error),
+    #[error("invalid bind target `{0}`")]
+    InvalidBind(String),
 }
 
 #[derive(Debug, Serialize)]
@@ -327,11 +331,71 @@ pub fn build_router(state: AdminState) -> Router {
 }
 
 pub async fn serve(bind: &str, state: AdminState) -> Result<(), AdminError> {
-    let addr: SocketAddr = bind.parse()?;
-    let listener = TcpListener::bind(addr).await?;
-    let app = build_router(state);
-    axum::serve(listener, app).await?;
-    Ok(())
+    serve_with_shutdown(bind, state, std::future::pending::<()>()).await
+}
+
+pub async fn serve_with_shutdown<F>(
+    bind: &str,
+    state: AdminState,
+    shutdown: F,
+) -> Result<(), AdminError>
+where
+    F: Future<Output = ()> + Send + 'static,
+{
+    if let Ok(addr) = bind.parse::<SocketAddr>() {
+        let listener = TcpListener::bind(addr).await?;
+        let app = build_router(state);
+        axum::serve(listener, app)
+            .with_graceful_shutdown(shutdown)
+            .await?;
+        return Ok(());
+    }
+
+    #[cfg(unix)]
+    {
+        let socket_path = normalize_unix_socket_path(bind)?;
+        let listener = bind_unix_listener(&socket_path)?;
+        let app = build_router(state);
+        let result = axum::serve(listener, app)
+            .with_graceful_shutdown(shutdown)
+            .await;
+        cleanup_unix_socket(&socket_path)?;
+        result?;
+        Ok(())
+    }
+
+    #[cfg(not(unix))]
+    {
+        let _ = (state, shutdown);
+        Err(AdminError::InvalidBind(bind.to_string()))
+    }
+}
+
+#[cfg(unix)]
+fn normalize_unix_socket_path(raw: &str) -> Result<PathBuf, AdminError> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return Err(AdminError::InvalidBind(raw.to_string()));
+    }
+    Ok(PathBuf::from(trimmed))
+}
+
+#[cfg(unix)]
+fn bind_unix_listener(path: &Path) -> Result<tokio::net::UnixListener, AdminError> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    cleanup_unix_socket(path)?;
+    Ok(tokio::net::UnixListener::bind(path)?)
+}
+
+#[cfg(unix)]
+fn cleanup_unix_socket(path: &Path) -> Result<(), AdminError> {
+    match std::fs::remove_file(path) {
+        Ok(_) => Ok(()),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(AdminError::Io(error)),
+    }
 }
 
 async fn get_health(State(state): State<AdminState>) -> Response {

--- a/crates/penny-cli/Cargo.toml
+++ b/crates/penny-cli/Cargo.toml
@@ -13,13 +13,17 @@ penny-cost = { path = "../penny-cost" }
 penny-config = { path = "../penny-config" }
 penny-store = { path = "../penny-store" }
 penny-types = { path = "../penny-types" }
+penny-admin = { path = "../penny-admin" }
+penny-detect = { path = "../penny-detect" }
+penny-providers = { path = "../penny-providers" }
+penny-proxy = { path = "../penny-proxy" }
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls", "stream"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 sqlx = { version = "0.8", features = ["runtime-tokio-rustls", "sqlite"] }
 tempfile = "3"
 thiserror = "1"
-tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
+tokio = { version = "1", features = ["macros", "rt-multi-thread", "net", "signal", "time"] }
 toml = "0.8"
 
 [dev-dependencies]

--- a/crates/penny-cli/src/main.rs
+++ b/crates/penny-cli/src/main.rs
@@ -3,6 +3,7 @@ use std::{
     collections::{BTreeSet, HashMap},
     fs,
     path::{Path, PathBuf},
+    sync::Arc,
     time::Duration,
 };
 
@@ -10,11 +11,18 @@ use chrono::{DateTime, Utc};
 use clap::{Parser, Subcommand, ValueEnum};
 use comfy_table::{presets::UTF8_FULL, Attribute, Cell, Table};
 use glob::glob;
+use penny_admin::{self, AdminState};
 use penny_config::{
-    load_config, resolve_user_config_path, ConfigError, LoadOptions, PRESET_EXPLORE, PRESET_INDIE,
-    PRESET_TEAM,
+    load_config, resolve_user_config_path, AppConfig, ConfigError, LoadOptions, PRESET_EXPLORE,
+    PRESET_INDIE, PRESET_TEAM,
 };
 use penny_cost::{estimate_tokens, import_pricebook_files, PricingEngine};
+use penny_detect::DetectEngine;
+use penny_providers::{
+    AnthropicProvider, AnthropicProviderConfig, MockProvider, MockProviderConfig, OpenAiProvider,
+    OpenAiProviderConfig, ProviderAdapter,
+};
+use penny_proxy::{self, build_state_from_config};
 use penny_store::{BudgetRepo, ProjectRepo, SessionRepo, SqliteStore};
 use penny_types::{Budget, Confidence, Event, EventType, Money, ScopeType, TaskType, WindowType};
 use reqwest::Client;
@@ -93,6 +101,14 @@ enum Commands {
         cwd: Option<PathBuf>,
         #[arg(long, default_value_t = false)]
         json: bool,
+    },
+    Serve {
+        #[arg(long, default_value_t = false)]
+        mock: bool,
+        #[arg(long)]
+        proxy_bind: Option<String>,
+        #[arg(long)]
+        admin_bind: Option<String>,
     },
     Tail {
         #[arg(long, default_value = "http://127.0.0.1:8586")]
@@ -389,6 +405,18 @@ struct RunCommand {
     as_json: bool,
 }
 
+#[derive(Debug, Clone)]
+struct ServeCommand {
+    mock: bool,
+    proxy_bind: Option<String>,
+    admin_bind: Option<String>,
+}
+
+struct RuntimeProvider {
+    provider: Arc<dyn ProviderAdapter>,
+    models: Vec<String>,
+}
+
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 struct LaunchPlan {
     mode: String,
@@ -592,6 +620,21 @@ async fn run(cli: Cli) -> Result<(), CliError> {
                     session_id,
                     cwd,
                     as_json: json,
+                },
+            )
+            .await?;
+        }
+        Commands::Serve {
+            mock,
+            proxy_bind,
+            admin_bind,
+        } => {
+            run_serve(
+                &store,
+                ServeCommand {
+                    mock,
+                    proxy_bind,
+                    admin_bind,
                 },
             )
             .await?;
@@ -1049,6 +1092,279 @@ async fn run_launcher(store: &SqliteStore, command: RunCommand) -> Result<(), Cl
         println!("{}", render_launch_plan(&plan));
     }
     Ok(())
+}
+
+async fn run_serve(store: &SqliteStore, command: ServeCommand) -> Result<(), CliError> {
+    run_serve_with_shutdown(store, command, shutdown_signal()).await
+}
+
+async fn run_serve_with_shutdown<F>(
+    store: &SqliteStore,
+    command: ServeCommand,
+    shutdown: F,
+) -> Result<(), CliError>
+where
+    F: std::future::Future<Output = Result<&'static str, CliError>>,
+{
+    let config = load_runtime_config()?;
+    let proxy_bind = command
+        .proxy_bind
+        .unwrap_or_else(|| config.server.bind.clone());
+    let admin_bind = command
+        .admin_bind
+        .map(|value| expand_tilde(PathBuf::from(value)))
+        .unwrap_or_else(|| expand_tilde(PathBuf::from(config.server.admin_socket.clone())));
+    let runtime = build_runtime_provider(&config, command.mock)?;
+    let proxy_state =
+        build_state_from_config(runtime.provider, runtime.models, store.clone(), &config)
+            .await
+            .map_err(CliError::Run)?;
+    let admin_state = AdminState::new(store.clone())
+        .with_detector(Arc::new(DetectEngine::from_runtime_config(&config.detect)));
+
+    println!("Starting PennyPrompt serve");
+    println!("  mode: {}", if command.mock { "mock" } else { "runtime" });
+    println!("  proxy_bind: {proxy_bind}");
+    println!("  admin_bind: {}", admin_bind_display(&admin_bind));
+    println!("Press Ctrl+C to stop.");
+
+    let (shutdown_tx, _) = tokio::sync::broadcast::channel::<()>(4);
+
+    let proxy_bind_for_task = proxy_bind.clone();
+    let mut proxy_task = tokio::spawn({
+        let mut shutdown_rx = shutdown_tx.subscribe();
+        async move {
+            penny_proxy::serve_with_state_and_shutdown(
+                &proxy_bind_for_task,
+                proxy_state,
+                async move {
+                    let _ = shutdown_rx.recv().await;
+                },
+            )
+            .await
+        }
+    });
+
+    let admin_bind_for_task = admin_bind.clone();
+    let mut admin_task = tokio::spawn({
+        let mut shutdown_rx = shutdown_tx.subscribe();
+        async move {
+            penny_admin::serve_with_shutdown(&admin_bind_for_task, admin_state, async move {
+                let _ = shutdown_rx.recv().await;
+            })
+            .await
+        }
+    });
+
+    enum ServeExit {
+        Signal(&'static str),
+        Proxy(Result<Result<(), penny_proxy::ProxyError>, tokio::task::JoinError>),
+        Admin(Result<Result<(), penny_admin::AdminError>, tokio::task::JoinError>),
+    }
+
+    let mut shutdown = std::pin::pin!(shutdown);
+    let exit = tokio::select! {
+        signal = &mut shutdown => ServeExit::Signal(signal?),
+        proxy = &mut proxy_task => ServeExit::Proxy(proxy),
+        admin = &mut admin_task => ServeExit::Admin(admin),
+    };
+
+    match exit {
+        ServeExit::Signal(signal_name) => {
+            println!("Received {signal_name}, shutting down...");
+            let _ = shutdown_tx.send(());
+            map_proxy_task(proxy_task.await)?;
+            map_admin_task(admin_task.await)?;
+            println!("Serve shutdown complete.");
+            Ok(())
+        }
+        ServeExit::Proxy(result) => {
+            let _ = shutdown_tx.send(());
+            let _ = admin_task.await;
+            map_proxy_task(result)?;
+            Err(CliError::Run(
+                "proxy server stopped unexpectedly".to_string(),
+            ))
+        }
+        ServeExit::Admin(result) => {
+            let _ = shutdown_tx.send(());
+            let _ = proxy_task.await;
+            map_admin_task(result)?;
+            Err(CliError::Run(
+                "admin server stopped unexpectedly".to_string(),
+            ))
+        }
+    }
+}
+
+fn map_proxy_task(
+    result: Result<Result<(), penny_proxy::ProxyError>, tokio::task::JoinError>,
+) -> Result<(), CliError> {
+    let result =
+        result.map_err(|error| CliError::Run(format!("proxy task join error: {error}")))?;
+    result.map_err(|error| CliError::Run(format!("proxy server error: {error}")))
+}
+
+fn map_admin_task(
+    result: Result<Result<(), penny_admin::AdminError>, tokio::task::JoinError>,
+) -> Result<(), CliError> {
+    let result =
+        result.map_err(|error| CliError::Run(format!("admin task join error: {error}")))?;
+    result.map_err(|error| CliError::Run(format!("admin server error: {error}")))
+}
+
+fn admin_bind_display(bind: &str) -> String {
+    if bind.parse::<std::net::SocketAddr>().is_ok() {
+        format!("http://{bind}")
+    } else {
+        format!("unix://{bind}")
+    }
+}
+
+#[cfg(unix)]
+async fn shutdown_signal() -> Result<&'static str, CliError> {
+    use tokio::signal::unix::{signal, SignalKind};
+
+    let mut term =
+        signal(SignalKind::terminate()).map_err(|error| CliError::Run(error.to_string()))?;
+    tokio::select! {
+        signal = tokio::signal::ctrl_c() => {
+            signal.map_err(|error| CliError::Run(error.to_string()))?;
+            Ok("SIGINT")
+        }
+        _ = term.recv() => Ok("SIGTERM"),
+    }
+}
+
+#[cfg(not(unix))]
+async fn shutdown_signal() -> Result<&'static str, CliError> {
+    tokio::signal::ctrl_c()
+        .await
+        .map_err(|error| CliError::Run(error.to_string()))?;
+    Ok("CTRL_C")
+}
+
+fn build_runtime_provider(
+    config: &AppConfig,
+    mock_mode: bool,
+) -> Result<RuntimeProvider, CliError> {
+    if mock_mode {
+        let mock = MockProvider::new(MockProviderConfig::default());
+        let models = mock.config().supported_models.clone();
+        return Ok(RuntimeProvider {
+            provider: Arc::new(mock),
+            models,
+        });
+    }
+
+    let default_model = config.defaults.model.trim();
+    if default_model.is_empty() {
+        return Err(CliError::Run(
+            "defaults.model must not be empty".to_string(),
+        ));
+    }
+
+    match config.defaults.provider.trim() {
+        "anthropic" => {
+            if !config.providers.anthropic.enabled {
+                return Err(CliError::Run(
+                    "providers.anthropic is disabled but defaults.provider=anthropic".to_string(),
+                ));
+            }
+            let api_key = read_required_env(&config.providers.anthropic.api_key_env)?;
+            let models = build_supported_models(default_model, &["claude-sonnet-4-6"]);
+            let provider = AnthropicProvider::new(AnthropicProviderConfig {
+                provider_id: "anthropic".to_string(),
+                base_url: config.providers.anthropic.base_url.clone(),
+                api_key,
+                supported_models: models.clone(),
+                ..AnthropicProviderConfig::default()
+            })
+            .map_err(CliError::Run)?;
+            Ok(RuntimeProvider {
+                provider: Arc::new(provider),
+                models,
+            })
+        }
+        "openai" => {
+            if !config.providers.openai.enabled {
+                return Err(CliError::Run(
+                    "providers.openai is disabled but defaults.provider=openai".to_string(),
+                ));
+            }
+            let api_key = read_required_env(&config.providers.openai.api_key_env)?;
+            let models = build_supported_models(default_model, &["gpt-4.1"]);
+            let provider = OpenAiProvider::new(OpenAiProviderConfig {
+                provider_id: "openai".to_string(),
+                base_url: config.providers.openai.base_url.clone(),
+                api_key,
+                supported_models: models.clone(),
+                ..OpenAiProviderConfig::default()
+            })
+            .map_err(CliError::Run)?;
+            Ok(RuntimeProvider {
+                provider: Arc::new(provider),
+                models,
+            })
+        }
+        provider => Err(CliError::Run(format!(
+            "unsupported defaults.provider `{provider}` (expected anthropic|openai)"
+        ))),
+    }
+}
+
+fn load_runtime_config() -> Result<AppConfig, CliError> {
+    #[cfg(test)]
+    {
+        load_config(LoadOptions::default())
+            .or_else(|error| match error {
+                ConfigError::MissingDefaultConfig(_) => load_config(LoadOptions {
+                    repository_root: Some(PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../..")),
+                    ..Default::default()
+                }),
+                other => Err(other),
+            })
+            .map_err(|error| CliError::Config(error.to_string()))
+    }
+
+    #[cfg(not(test))]
+    {
+        load_config(LoadOptions::default()).map_err(|error| CliError::Config(error.to_string()))
+    }
+}
+
+fn read_required_env(var_name: &str) -> Result<String, CliError> {
+    let key = var_name.trim();
+    if key.is_empty() {
+        return Err(CliError::Run(
+            "provider api_key_env must not be empty".to_string(),
+        ));
+    }
+    let value = std::env::var(key).map_err(|_| {
+        CliError::Run(format!(
+            "missing required environment variable `{key}` for runtime provider auth"
+        ))
+    })?;
+    let value = value.trim();
+    if value.is_empty() {
+        return Err(CliError::Run(format!(
+            "environment variable `{key}` is empty"
+        )));
+    }
+    Ok(value.to_string())
+}
+
+fn build_supported_models(default_model: &str, baseline: &[&str]) -> Vec<String> {
+    let mut models = BTreeSet::new();
+    if !default_model.trim().is_empty() {
+        models.insert(default_model.trim().to_string());
+    }
+    for model in baseline {
+        if !model.trim().is_empty() {
+            models.insert(model.trim().to_string());
+        }
+    }
+    models.into_iter().collect()
 }
 
 async fn resolve_launch_project_id(
@@ -2432,6 +2748,7 @@ fn csv_escape(value: &str) -> Cow<'_, str> {
 #[cfg(test)]
 mod tests {
     use std::fs;
+    use std::net::TcpListener as StdTcpListener;
     use std::path::Path;
 
     use chrono::{Duration as ChronoDuration, TimeZone};
@@ -2445,6 +2762,27 @@ mod tests {
         SqliteStore::connect("sqlite::memory:")
             .await
             .expect("create in-memory store")
+    }
+
+    fn find_free_port() -> u16 {
+        StdTcpListener::bind("127.0.0.1:0")
+            .expect("bind ephemeral port")
+            .local_addr()
+            .expect("resolve local addr")
+            .port()
+    }
+
+    async fn wait_for_http_ready(url: &str) {
+        let client = Client::new();
+        for _ in 0..80 {
+            if let Ok(response) = client.get(url).send().await {
+                if response.status().is_success() {
+                    return;
+                }
+            }
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+        panic!("endpoint did not become ready: {url}");
     }
 
     struct RequestUsageFixture<'a> {
@@ -2799,6 +3137,77 @@ mod tests {
         assert_eq!(rows.len(), 1);
         assert!((rows[0].total_cost_usd - 2.0).abs() < 1e-9);
         assert_eq!(rows[0].request_count, 1);
+    }
+
+    #[tokio::test]
+    async fn serve_mock_starts_proxy_and_admin_and_shuts_down_cleanly() {
+        let store = setup_store().await;
+        let proxy_port = find_free_port();
+        let admin_port = find_free_port();
+        let proxy_bind = format!("127.0.0.1:{proxy_port}");
+        let admin_bind = format!("127.0.0.1:{admin_port}");
+        let proxy_url = format!("http://{proxy_bind}");
+        let admin_health_url = format!("http://{admin_bind}/admin/health");
+        let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel::<()>();
+
+        let serve_task = tokio::spawn({
+            let store = store.clone();
+            let proxy_bind = proxy_bind.clone();
+            let admin_bind = admin_bind.clone();
+            async move {
+                run_serve_with_shutdown(
+                    &store,
+                    ServeCommand {
+                        mock: true,
+                        proxy_bind: Some(proxy_bind),
+                        admin_bind: Some(admin_bind),
+                    },
+                    async move {
+                        let _ = shutdown_rx.await;
+                        Ok("TEST_SHUTDOWN")
+                    },
+                )
+                .await
+            }
+        });
+
+        wait_for_http_ready(&admin_health_url).await;
+
+        let client = Client::new();
+        let health_response = client
+            .get(&admin_health_url)
+            .send()
+            .await
+            .expect("admin health request");
+        assert_eq!(health_response.status(), 200);
+
+        let proxy_response = client
+            .post(format!("{proxy_url}/v1/chat/completions"))
+            .json(&json!({
+                "model": "claude-sonnet-4-6",
+                "messages": [{"role": "user", "content": "ping"}]
+            }))
+            .send()
+            .await
+            .expect("proxy completion request");
+        assert!(
+            proxy_response.status() == 200 || proxy_response.status() == 402,
+            "unexpected proxy status: {}",
+            proxy_response.status()
+        );
+        let payload: Value = proxy_response
+            .json()
+            .await
+            .expect("parse proxy completion payload");
+        if payload.get("choices").is_some() {
+            assert_eq!(payload["choices"][0]["message"]["role"], "assistant");
+        } else {
+            assert_eq!(payload["error"]["retryable"], false);
+        }
+
+        shutdown_tx.send(()).expect("send shutdown");
+        let serve_result = serve_task.await.expect("join serve task");
+        assert!(serve_result.is_ok(), "serve task failed: {serve_result:?}");
     }
 
     #[test]

--- a/crates/penny-proxy/src/lib.rs
+++ b/crates/penny-proxy/src/lib.rs
@@ -2,6 +2,7 @@
 
 use std::{
     convert::Infallible,
+    future::Future,
     hash::Hasher,
     net::SocketAddr,
     path::{Path, PathBuf},
@@ -281,10 +282,27 @@ pub async fn serve_default() -> Result<(), ProxyError> {
 }
 
 pub async fn serve(bind: &str) -> Result<(), ProxyError> {
+    serve_with_state(bind, ProxyState::mock_default()).await
+}
+
+pub async fn serve_with_state(bind: &str, state: ProxyState) -> Result<(), ProxyError> {
+    serve_with_state_and_shutdown(bind, state, std::future::pending::<()>()).await
+}
+
+pub async fn serve_with_state_and_shutdown<F>(
+    bind: &str,
+    state: ProxyState,
+    shutdown: F,
+) -> Result<(), ProxyError>
+where
+    F: Future<Output = ()> + Send + 'static,
+{
     let addr: SocketAddr = bind.parse()?;
     let listener = TcpListener::bind(addr).await?;
-    let app = build_router(ProxyState::mock_default());
-    axum::serve(listener, app).await?;
+    let app = build_router(state);
+    axum::serve(listener, app)
+        .with_graceful_shutdown(shutdown)
+        .await?;
     Ok(())
 }
 


### PR DESCRIPTION
## Summary
Implements `pennyprompt serve` in the CLI runtime, wiring proxy + admin startup/lifecycle with graceful shutdown.

## What changed
- Added `serve` subcommand in `penny-cli`:
  - `--mock`
  - `--proxy-bind`
  - `--admin-bind`
- Added runtime provider wiring (mock/openai/anthropic) and proxy state bootstrap from config.
- Added coordinated shutdown flow on `SIGINT`/`SIGTERM`.
- Added proxy helper `serve_with_state_and_shutdown`.
- Added admin helper `serve_with_shutdown` with TCP/Unix socket binding and socket cleanup.
- Added e2e test that starts serve in mock mode, validates:
  - `GET /admin/health`
  - one proxy request path through `/v1/chat/completions`
  - clean shutdown
- Updated README bind behavior and CLI reference for `serve`.

## Validation
- `cargo fmt --all`
- `cargo check --workspace`
- `cargo test --workspace`
- `cargo clippy --workspace --all-targets`

Closes #129
