### PR TITLE
docs: reconcile command surface, models, and admin bind semantics (#130)

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Your AI agent just burned $47 debugging a typo. You didn't know until Tuesday.
 **PennyPrompt is a local reverse proxy (~15MB, single binary, zero dependencies) that sits between your AI agent and your LLM provider.** It estimates costs before execution, enforces budgets with hard stops, detects runaway loops, and generates forensic reports — all without changing a single line in your existing workflow.
 
 ```
-Your Agent ──→ PennyPrompt (:8585) ──→ Anthropic / OpenAI / Ollama
+Your Agent ──→ PennyPrompt (:8585) ──→ Anthropic / OpenAI
                     │
                     ├── Budget check (atomic, with reservations)
                     ├── Loop detection (burn-rate, repeated failures)
@@ -69,7 +69,7 @@ $ pennyprompt report summary --since 1d
 
   By Model:
     claude-sonnet-4-6    $3.41  (80.7%)  48 reqs
-    gpt-5.2              $0.82  (19.3%)  19 reqs
+    gpt-4.1              $0.82  (19.3%)  19 reqs
 
   By Project:
     webapp               $3.89  (92.0%)
@@ -131,11 +131,11 @@ Configurable actions: `alert` (log + show in `tail`) or `pause` (block session u
 ### Pre-Execution Cost Estimation
 
 ```bash
-$ pennyprompt estimate --model sonnet --context-files src/auth/
+$ pennyprompt estimate --model claude-sonnet-4-6 --context-files src/auth/
 
-  Sonnet 4.6:  $0.12 – $0.45 (single pass) | $0.60 – $2.25 (agent task)
-  Opus 4.6:    $0.35 – $1.25 (single pass) | $1.75 – $6.25 (agent task)
-  Haiku 4.5:   $0.04 – $0.15 (single pass) | $0.20 – $0.75 (agent task)
+  claude-sonnet-4-6:  $0.12 – $0.45 (single pass) | $0.60 – $2.25 (agent task)
+  claude-opus-4-1:    $0.35 – $1.25 (single pass) | $1.75 – $6.25 (agent task)
+  claude-haiku-4:     $0.04 – $0.15 (single pass) | $0.20 – $0.75 (agent task)
 
   Budget: OK (day: $6.59 remaining of $10.00)
 ```
@@ -254,7 +254,7 @@ All config values can be overridden via environment variables with the `PENNY_` 
 
 ```bash
 PENNY_SERVER_BIND=0.0.0.0:8585
-PENNY_DEFAULTS_MODEL=claude-opus-4-6
+PENNY_DEFAULTS_MODEL=claude-opus-4-1
 ```
 
 `pennyprompt serve` bind behavior:
@@ -271,7 +271,7 @@ Pricing is stored locally in versioned TOML files (`prices/anthropic.toml`, `pri
 
 ```bash
 pennyprompt prices show            # Current prices
-pennyprompt prices update          # Download latest from PennyPrompt repo
+pennyprompt prices update          # Import bundled local pricebook files
 ```
 
 ## CLI Reference
@@ -281,9 +281,9 @@ pennyprompt
 ├── init [--preset indie|team|explore]     Setup wizard
 ├── serve [--mock] [--proxy-bind] [--admin-bind]  Start proxy + admin
 ├── estimate [--model M] [--context-files]  Pre-execution cost estimate
+├── run <agent> [--json]                    Launcher dry-run plan
 ├── report
 │   ├── summary [--since] [--by project|model|session]
-│   ├── session <id>                        Session detail
 │   └── top [--limit N]                     Most expensive requests
 ├── budget
 │   ├── list                                Active budgets + status
@@ -296,9 +296,9 @@ pennyprompt
 ├── doctor                                  System diagnostics
 ├── prices
 │   ├── show                                Current pricebook
-│   └── update                              Download latest prices
+│   └── update                              Import bundled local pricebook files
 ├── config                                  Show effective config
-└── version
+└── dashboard [--since] [--limit]           Snapshot KPIs by project/model
 ```
 
 ## Architecture

--- a/docs/CONFIG-REFERENCE.md
+++ b/docs/CONFIG-REFERENCE.md
@@ -32,9 +32,16 @@ Config is resolved in this order (later overrides earlier):
 ## `[server]`
 
 - `bind` (`string`): proxy bind address (example `127.0.0.1:8585`)
-- `admin_socket` (`string`): admin socket path
+- `admin_socket` (`string`): admin bind target
+  - if value is `host:port`, admin binds TCP
+  - otherwise admin binds a Unix socket path
 - `database_path` (`string`): SQLite database path
 - `mode` (`observe|guard`)
+
+Operational note:
+
+- `tail` / `detect` CLI commands use HTTP URLs and default to `http://127.0.0.1:8586`.
+- If you keep `admin_socket` as a Unix path, start serve with `--admin-bind 127.0.0.1:8586` for those commands, or pass an explicit reachable admin URL.
 
 ## `[defaults]`
 

--- a/docs/LIMITATIONS.md
+++ b/docs/LIMITATIONS.md
@@ -4,7 +4,7 @@ This list documents current constraints as of April 18, 2026.
 
 ## CLI / Product Surface
 
-- `serve` lifecycle orchestration is not fully consolidated in `penny-cli` yet.
+- `serve` is available in `penny-cli`, but daemon/background mode is not implemented yet.
 - `run <agent>` currently emits deterministic dry-run launch plans; full process orchestration remains a follow-up.
 - Some outputs are operator-focused and intentionally minimal (not final UX polish).
 
@@ -20,7 +20,8 @@ This list documents current constraints as of April 18, 2026.
 
 ## API/Control Plane Assumptions
 
-- `tail` and `detect` control commands assume admin API availability (default `http://127.0.0.1:8586` in CLI commands).
+- `tail` and `detect` control commands assume admin API availability over HTTP (default `http://127.0.0.1:8586` in CLI commands).
+- If `serve` runs admin on a Unix socket path, use `--admin-bind 127.0.0.1:8586` (or equivalent TCP bind) for those commands.
 - If admin plane is unavailable, related commands fail as expected.
 
 ## Data and Reporting

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -54,7 +54,21 @@ export OPENAI_API_KEY=...
 ./target/release/penny-cli config --json
 ```
 
-## 6. Try Core Operator Commands
+## 6. Start Proxy + Admin Planes
+
+Run `serve` in terminal A and keep it running:
+
+```bash
+./target/release/penny-cli serve --admin-bind 127.0.0.1:8586
+```
+
+If you want a fully local smoke test without provider keys:
+
+```bash
+./target/release/penny-cli serve --mock --admin-bind 127.0.0.1:8586
+```
+
+## 7. Try Core Operator Commands (terminal B)
 
 Estimate:
 
@@ -84,10 +98,10 @@ Reports:
 ./target/release/penny-cli report top --limit 20
 ```
 
-## 7. Optional Live Monitoring (if admin plane is running)
+Live monitoring:
 
 ```bash
-./target/release/penny-cli tail --admin-url http://127.0.0.1:8586
+./target/release/penny-cli tail
 ```
 
 Resume a paused session:
@@ -114,6 +128,7 @@ Notes:
 
 - `doctor` shows config and DB status.
 - `prices show` lists active models and rates.
+- `serve` starts both proxy and admin without missing-command errors.
 - `estimate` returns min/max range and budget impact.
 - `report` commands return either data or explicit "no usage rows" output.
 


### PR DESCRIPTION
## Summary
Reconciles operator documentation with the currently shipped CLI surface and runtime behavior.

## What changed
- Updated README command reference to match actual CLI commands (removed non-existent entries, added `run` and `dashboard`).
- Updated README examples to use models present in the current pricebooks.
- Clarified `prices update` wording to reflect bundled local import behavior.
- Updated QUICKSTART to include real `serve` startup flow and consistent admin endpoint usage for `tail`/`detect`.
- Updated CONFIG-REFERENCE to document `server.admin_socket` bind semantics (TCP `host:port` vs Unix socket path).
- Updated LIMITATIONS to reflect current state (`serve` implemented, daemon mode deferred).

## Acceptance alignment
- New users can follow docs without missing-command mismatches.
- Example model IDs now exist in pricebooks.
- Admin bind/access behavior is documented consistently across core docs.

Closes #130
