### PR TITLE
feat(pricing): refresh local pricebooks and enforce default-model resolvability guardrail (#131)

### DIFF
--- a/crates/penny-cli/src/main.rs
+++ b/crates/penny-cli/src/main.rs
@@ -23,7 +23,7 @@ use penny_providers::{
     OpenAiProviderConfig, ProviderAdapter,
 };
 use penny_proxy::{self, build_state_from_config};
-use penny_store::{BudgetRepo, ProjectRepo, SessionRepo, SqliteStore};
+use penny_store::{BudgetRepo, PricebookRepo, ProjectRepo, SessionRepo, SqliteStore};
 use penny_types::{Budget, Confidence, Event, EventType, Money, ScopeType, TaskType, WindowType};
 use reqwest::Client;
 use serde::{Deserialize, Serialize};
@@ -825,9 +825,76 @@ async fn run_prices_update(store: &SqliteStore) -> Result<(), CliError> {
     let imported = import_pricebook_files(store, &[anthropic.clone(), openai.clone()])
         .await
         .map_err(|error| CliError::Cost(error.to_string()))?;
+    let mut guardrail_models = preset_default_models()?;
+    if let Ok(config) = load_config(LoadOptions::default()) {
+        guardrail_models.push(config.defaults.model);
+    }
+    guardrail_models.sort();
+    guardrail_models.dedup();
+    validate_pricebook_models_resolvable(store, &guardrail_models).await?;
     println!("Pricebook update completed");
     println!("  imported_entries: {imported}");
+    println!("  validated_default_models: {}", guardrail_models.len());
     Ok(())
+}
+
+fn preset_default_models() -> Result<Vec<String>, CliError> {
+    let preset_sources = [
+        (PRESET_INDIE, PRESET_INDIE_TOML),
+        (PRESET_TEAM, PRESET_TEAM_TOML),
+        (PRESET_EXPLORE, PRESET_EXPLORE_TOML),
+    ];
+    let mut models = Vec::with_capacity(preset_sources.len());
+
+    for (preset_name, raw) in preset_sources {
+        let parsed: toml::Value = toml::from_str(raw).map_err(|error| {
+            CliError::Cost(format!(
+                "failed to parse embedded preset `{preset_name}` while validating pricebook models: {error}"
+            ))
+        })?;
+        let model = parsed
+            .get("defaults")
+            .and_then(|defaults| defaults.get("model"))
+            .and_then(toml::Value::as_str)
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .ok_or_else(|| {
+                CliError::Cost(format!(
+                    "embedded preset `{preset_name}` has missing defaults.model"
+                ))
+            })?;
+        models.push(model.to_string());
+    }
+
+    Ok(models)
+}
+
+async fn validate_pricebook_models_resolvable(
+    store: &SqliteStore,
+    model_ids: &[String],
+) -> Result<(), CliError> {
+    let now = Utc::now();
+    let mut unresolved = Vec::new();
+    for model_id in model_ids {
+        let maybe_entry = store
+            .get_price(model_id, now)
+            .await
+            .map_err(|error| CliError::Cost(error.to_string()))?;
+        if maybe_entry.is_none() {
+            unresolved.push(model_id.clone());
+        }
+    }
+
+    if unresolved.is_empty() {
+        Ok(())
+    } else {
+        unresolved.sort();
+        unresolved.dedup();
+        Err(CliError::Cost(format!(
+            "pricebook update guardrail: unresolved defaults.model entries: {}",
+            unresolved.join(", ")
+        )))
+    }
 }
 
 async fn run_budget_list(store: &SqliteStore) -> Result<(), CliError> {
@@ -3137,6 +3204,31 @@ mod tests {
         assert_eq!(rows.len(), 1);
         assert!((rows[0].total_cost_usd - 2.0).abs() < 1e-9);
         assert_eq!(rows[0].request_count, 1);
+    }
+
+    #[tokio::test]
+    async fn prices_update_guardrail_validates_preset_models() {
+        let store = setup_store().await;
+        run_prices_update(&store).await.expect("prices update");
+        let preset_models = preset_default_models().expect("preset models");
+        validate_pricebook_models_resolvable(&store, &preset_models)
+            .await
+            .expect("preset models must resolve");
+    }
+
+    #[tokio::test]
+    async fn prices_update_guardrail_rejects_unresolved_defaults() {
+        let store = setup_store().await;
+        let error = validate_pricebook_models_resolvable(
+            &store,
+            &[String::from("missing-model-id-for-test")],
+        )
+        .await
+        .expect_err("missing model must fail guardrail");
+
+        let rendered = error.to_string();
+        assert!(rendered.contains("unresolved defaults.model entries"));
+        assert!(rendered.contains("missing-model-id-for-test"));
     }
 
     #[tokio::test]

--- a/crates/penny-cost/src/lib.rs
+++ b/crates/penny-cost/src/lib.rs
@@ -386,6 +386,62 @@ mod tests {
         assert_eq!(snapshot["source"], "local");
     }
 
+    #[tokio::test]
+    async fn calculate_prefers_latest_effective_entry_for_model() {
+        let store = SqliteStore::connect("sqlite::memory:")
+            .await
+            .expect("create store");
+        sqlx::query(
+            "INSERT INTO providers (id, name, base_url, api_format, enabled) VALUES ('test-provider', 'Test Provider', 'https://example.invalid', 'openai', 1)",
+        )
+        .execute(store.pool())
+        .await
+        .expect("insert provider");
+        sqlx::query(
+            "INSERT INTO models (id, provider_id, external_name, display_name, class) VALUES ('test-model', 'test-provider', 'test-model', 'Test Model', 'balanced')",
+        )
+        .execute(store.pool())
+        .await
+        .expect("insert model");
+
+        PricebookRepo::import(
+            &store,
+            &[
+                NewPricebookEntry {
+                    model_id: "test-model".to_string(),
+                    input_per_mtok: Money::from_usd(1.0).expect("money"),
+                    output_per_mtok: Money::from_usd(2.0).expect("money"),
+                    effective_from: parse_datetime("2026-04-10T00:00:00Z", "effective_from")
+                        .expect("datetime"),
+                    effective_until: Some(
+                        parse_datetime("2026-04-25T00:00:00Z", "effective_until")
+                            .expect("datetime"),
+                    ),
+                    source: "local".to_string(),
+                },
+                NewPricebookEntry {
+                    model_id: "test-model".to_string(),
+                    input_per_mtok: Money::from_usd(3.0).expect("money"),
+                    output_per_mtok: Money::from_usd(4.0).expect("money"),
+                    effective_from: parse_datetime("2026-04-25T00:00:00Z", "effective_from")
+                        .expect("datetime"),
+                    effective_until: None,
+                    source: "local".to_string(),
+                },
+            ],
+        )
+        .await
+        .expect("import versioned entries");
+
+        let engine = PricingEngine::new(&store);
+        let cost = engine
+            .calculate("test-model", 1_000_000, 1_000_000)
+            .await
+            .expect("calculate cost");
+
+        assert_eq!(cost, Money::from_usd(7.0).expect("money"));
+    }
+
     #[test]
     fn token_estimation_uses_cl100k_when_text_exists() {
         let payload = serde_json::json!([

--- a/presets/explore.toml
+++ b/presets/explore.toml
@@ -3,7 +3,7 @@ mode = "observe"
 
 [defaults]
 provider = "anthropic"
-model = "claude-haiku-4-5"
+model = "claude-haiku-4"
 
 [[budgets]]
 scope_type = "global"

--- a/prices/anthropic.toml
+++ b/prices/anthropic.toml
@@ -10,7 +10,7 @@ display_name = "Claude Opus 4.1"
 class = "premium"
 input_per_mtok = 15.0
 output_per_mtok = 75.0
-effective_from = "2026-04-10T00:00:00Z"
+effective_from = "2026-04-25T00:00:00Z"
 
 [[entries]]
 model_id = "claude-sonnet-4-6"
@@ -19,7 +19,7 @@ display_name = "Claude Sonnet 4.6"
 class = "balanced"
 input_per_mtok = 3.0
 output_per_mtok = 15.0
-effective_from = "2026-04-10T00:00:00Z"
+effective_from = "2026-04-25T00:00:00Z"
 
 [[entries]]
 model_id = "claude-haiku-4"
@@ -28,4 +28,4 @@ display_name = "Claude Haiku 4"
 class = "fast"
 input_per_mtok = 0.8
 output_per_mtok = 4.0
-effective_from = "2026-04-10T00:00:00Z"
+effective_from = "2026-04-25T00:00:00Z"

--- a/prices/openai.toml
+++ b/prices/openai.toml
@@ -10,7 +10,7 @@ display_name = "GPT-4.1"
 class = "balanced"
 input_per_mtok = 2.0
 output_per_mtok = 8.0
-effective_from = "2026-04-10T00:00:00Z"
+effective_from = "2026-04-25T00:00:00Z"
 
 [[entries]]
 model_id = "gpt-4.1-mini"
@@ -19,7 +19,7 @@ display_name = "GPT-4.1 Mini"
 class = "fast"
 input_per_mtok = 0.4
 output_per_mtok = 1.6
-effective_from = "2026-04-10T00:00:00Z"
+effective_from = "2026-04-25T00:00:00Z"
 
 [[entries]]
 model_id = "gpt-4o-mini"
@@ -28,4 +28,4 @@ display_name = "GPT-4o Mini"
 class = "fast"
 input_per_mtok = 0.15
 output_per_mtok = 0.6
-effective_from = "2026-04-10T00:00:00Z"
+effective_from = "2026-04-25T00:00:00Z"


### PR DESCRIPTION
## Summary
Implements P0 issue #131 by refreshing local pricebook metadata, aligning preset defaults with resolvable models, and adding deterministic guardrails/tests for model resolution.

## What changed
- Added `prices update` guardrail in CLI:
  - validates preset default models (`indie`, `team`, `explore`) resolve to active pricebook entries
  - validates effective config `defaults.model` when available
  - fails fast with explicit unresolved model IDs instead of allowing silent fallback
- Added tests in `penny-cli` for:
  - successful guardrail validation after `prices update`
  - guardrail failure path for unresolved defaults
- Added pricing-engine test for latest effective entry selection across versioned rows (`effective_from`/`effective_until`)
- Updated `presets/explore.toml` default model to a resolvable model ID
- Refreshed local pricebook `effective_from` timestamps in `prices/anthropic.toml` and `prices/openai.toml`

## Validation
- `cargo fmt --all`
- `cargo check --workspace`
- `cargo test --workspace`
- `cargo clippy --workspace --all-targets`

Closes #131
