### PR TITLE
docs(release): add v0.1.0-alpha.2 gate checklist and release-notes template (#132)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 - Upcoming changes are tracked via issue-first workflow and merged through PRs.
+- Alpha.2 release gate artifacts: targeted checklist, linked release process gate, and draft release notes template.
 
 ## [v0.1.0-alpha.1] - 2026-04-18
 
@@ -17,4 +18,3 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Integration and golden coverage for admin, proxy, ledger, and CLI event formatting.
 - Release automation workflow for macOS/Linux on x86_64 and arm64 with per-artifact SHA-256 checksums.
 - `scripts/install.sh` bootstrap installer for `curl | sh` installs from GitHub Releases.
-

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -2,6 +2,12 @@
 
 This document defines the repeatable process for alpha releases.
 
+## Release Gates
+
+- Generic alpha manual checklist: [`docs/ALPHA-MANUAL-CHECKLIST.md`](./ALPHA-MANUAL-CHECKLIST.md)
+- Targeted gate for current cut: [`docs/RELEASE_GATE_v0.1.0-alpha.2.md`](./RELEASE_GATE_v0.1.0-alpha.2.md)
+- Release notes draft for current cut: [`docs/release-notes/v0.1.0-alpha.2.md`](./release-notes/v0.1.0-alpha.2.md)
+
 ## Scope
 
 Current release automation builds and publishes `penny-cli` binaries for:
@@ -30,28 +36,32 @@ Manual trigger is also available via `workflow_dispatch`.
 ## Cut a Release
 
 1. Ensure `main` is green and synchronized.
-2. Update `CHANGELOG.md`.
-3. Create and push a tag:
+2. Complete the active release gate checklist (`RELEASE_GATE_v0.1.0-alpha.2.md` for alpha.2).
+3. Update `CHANGELOG.md` and finalize release notes draft.
+4. Confirm release notes include resolved blocking issues and known limitations link.
+5. Create and push a tag:
 
 ```bash
 git switch main
 git pull --ff-only origin main
-git tag v0.1.0-alpha.1
-git push origin v0.1.0-alpha.1
+git tag v0.1.0-alpha.2
+git push origin v0.1.0-alpha.2
 ```
 
-4. Wait for the `Release` workflow to finish.
-5. Verify GitHub Release contains:
+6. Wait for the `Release` workflow to finish.
+7. Verify GitHub Release contains:
 - 4 target archives (`penny-cli-vX.Y.Z-<target>.tar.gz`)
 - 4 checksum files (`.sha256`)
 - `CHECKSUMS.txt`
+
+For other versions, replace the tag value and keep the same gate sequence.
 
 ## Artifact Verification
 
 Download one artifact and verify:
 
 ```bash
-shasum -a 256 -c penny-cli-v0.1.0-alpha.1-x86_64-unknown-linux-gnu.sha256
+shasum -a 256 -c penny-cli-v0.1.0-alpha.2-x86_64-unknown-linux-gnu.sha256
 ```
 
 If `shasum` is unavailable, use `sha256sum -c`.
@@ -79,6 +89,5 @@ curl -fsSL https://raw.githubusercontent.com/manuelpenazuniga/PennyPrompt/main/s
 Pinned version:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/manuelpenazuniga/PennyPrompt/main/scripts/install.sh | PENNY_VERSION=v0.1.0-alpha.1 sh
+curl -fsSL https://raw.githubusercontent.com/manuelpenazuniga/PennyPrompt/main/scripts/install.sh | PENNY_VERSION=v0.1.0-alpha.2 sh
 ```
-

--- a/docs/RELEASE_GATE_v0.1.0-alpha.2.md
+++ b/docs/RELEASE_GATE_v0.1.0-alpha.2.md
@@ -1,0 +1,67 @@
+# Release Gate: v0.1.0-alpha.2
+
+Objective gate for publishing `v0.1.0-alpha.2` after P0 onboarding/contract fixes.
+
+## 1. Scope Lock (P0 Closure)
+
+- [ ] `#129` merged: `serve` command starts proxy + admin lifecycle from `penny-cli`.
+- [ ] `#130` merged: README/operator docs aligned with actual command surface.
+- [ ] `#131` merged: pricebooks refreshed and preset defaults resolvable.
+
+## 2. Workspace Quality Gate
+
+Run on release candidate branch (or `main` immediately before tagging):
+
+- [ ] `cargo fmt --all -- --check`
+- [ ] `cargo check --workspace --locked`
+- [ ] `cargo test --workspace --locked`
+- [ ] `cargo clippy --workspace --all-targets --locked -- -D warnings`
+
+## 3. Runtime Acceptance Smoke Tests
+
+Use a fresh shell and clean local config where possible.
+
+- [ ] `penny-cli init --preset indie` succeeds.
+- [ ] `penny-cli prices update` succeeds and reports validated default models.
+- [ ] `penny-cli prices show --limit 20` shows active entries with expected models (`claude-sonnet-4-6`, `claude-haiku-4`, `gpt-4.1` at minimum).
+- [ ] `penny-cli serve --mock --admin-bind 127.0.0.1:8586` starts both planes.
+- [ ] `curl -fsS http://127.0.0.1:8586/admin/health` returns `200`.
+- [ ] Proxy request path works against `http://127.0.0.1:8585/v1/chat/completions`.
+- [ ] `penny-cli tail` can consume admin events when admin is bound on TCP.
+
+## 4. Docs Consistency Gate
+
+- [ ] `README.md` quickstart and CLI reference match the current binary.
+- [ ] `docs/QUICKSTART.md` includes real `serve` flow.
+- [ ] `docs/CONFIG-REFERENCE.md` reflects current admin bind semantics.
+- [ ] `docs/LIMITATIONS.md` reflects current deferred behavior.
+- [ ] `CHANGELOG.md` contains `v0.1.0-alpha.2` notes before tag push.
+
+## 5. CI and Release Workflow Gate
+
+- [ ] Latest PR to `main` has CI check `Check, Test, Clippy, Fmt` green.
+- [ ] Release workflow (`.github/workflows/release.yml`) succeeded for all targets:
+  - [ ] `x86_64-unknown-linux-gnu`
+  - [ ] `aarch64-unknown-linux-gnu`
+  - [ ] `x86_64-apple-darwin`
+  - [ ] `aarch64-apple-darwin`
+
+## 6. Artifact Verification Gate
+
+- [ ] Release has 4 `.tar.gz` artifacts and 4 `.sha256` files.
+- [ ] `CHECKSUMS.txt` present and complete.
+- [ ] At least one target checksum verified locally (`shasum -a 256 -c ...`).
+
+## 7. Release Notes Gate
+
+Before publishing, prepare notes from `docs/release-notes/v0.1.0-alpha.2.md`.
+
+- [ ] Notes include explicit references to resolved P0 issues: `#129`, `#130`, `#131`.
+- [ ] Notes include link to known limitations: `docs/LIMITATIONS.md`.
+- [ ] Notes include validation statement (`fmt/check/test/clippy` passed).
+
+## 8. Publish Decision
+
+- [ ] All required boxes above are checked.
+- [ ] Remaining non-blocking items are tracked in open issues.
+- [ ] Tag pushed as `v0.1.0-alpha.2`.

--- a/docs/release-notes/v0.1.0-alpha.2.md
+++ b/docs/release-notes/v0.1.0-alpha.2.md
@@ -1,0 +1,27 @@
+# PennyPrompt v0.1.0-alpha.2 (Draft Notes)
+
+## Summary
+
+This alpha.2 cut closes the P0 onboarding and product-contract gaps found in the post-alpha audit.
+
+## Resolved P0 Issues
+
+- Closes #129: `penny-cli serve` now runs proxy + admin lifecycle with graceful shutdown.
+- Closes #130: README/operator docs now match the shipped command surface.
+- Closes #131: pricebooks refreshed and preset defaults validated as resolvable.
+
+## Validation
+
+- `cargo fmt --all -- --check`
+- `cargo check --workspace --locked`
+- `cargo test --workspace --locked`
+- `cargo clippy --workspace --all-targets --locked -- -D warnings`
+
+## Known Limitations
+
+Current alpha limitations are documented in [docs/LIMITATIONS.md](../LIMITATIONS.md).
+
+## Artifacts
+
+- 4 target archives (`.tar.gz`) for Linux/macOS on `x86_64` + `arm64`
+- Per-target SHA-256 files and aggregated `CHECKSUMS.txt`


### PR DESCRIPTION
## Summary
Implements the alpha.2 release gate requested in #132 with explicit checklist criteria, release-process linkage, and release-notes scaffolding.

## What changed
- Added targeted gate checklist for `v0.1.0-alpha.2`:
  - `docs/RELEASE_GATE_v0.1.0-alpha.2.md`
  - Includes P0 closure verification (`#129`, `#130`, `#131`), quality checks, runtime smoke tests, docs consistency, CI/release workflow checks, artifact verification, and publish decision criteria.
- Added release notes draft template:
  - `docs/release-notes/v0.1.0-alpha.2.md`
  - References resolved P0 issues and known limitations.
- Updated `docs/RELEASE.md`:
  - Linked the active gate checklist and release-notes draft.
  - Updated cut flow to require gate completion before tagging.
  - Updated examples to `v0.1.0-alpha.2`.
- Updated `CHANGELOG.md` (`Unreleased`) to track release-gate documentation additions.

## Acceptance Criteria Mapping (#132)
- Checklist exists in repo and is linked from release process docs: ✅
- Release gate defines objective criteria for serve/docs/pricebook/workspace checks: ✅
- Published notes template references resolved P0 issues and known limitations: ✅

## Validation
- `cargo fmt --all -- --check`
- `cargo check --workspace --locked`
- `cargo test --workspace --locked`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`

Closes #132
