### PR TITLE
feat(observe): add shared tracing bootstrap and runtime init

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1183,6 +1183,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
 name = "matchit"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1218,6 +1227,15 @@ checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
  "wasi",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
  "windows-sys 0.61.2",
 ]
 
@@ -1365,6 +1383,7 @@ dependencies = [
  "penny-config",
  "penny-cost",
  "penny-detect",
+ "penny-observe",
  "penny-providers",
  "penny-proxy",
  "penny-store",
@@ -1432,6 +1451,12 @@ dependencies = [
 [[package]]
 name = "penny-observe"
 version = "0.1.0"
+dependencies = [
+ "serde",
+ "thiserror 1.0.69",
+ "toml",
+ "tracing-subscriber",
+]
 
 [[package]]
 name = "penny-providers"
@@ -2020,6 +2045,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2401,6 +2435,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "tiktoken-rs"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2619,6 +2662,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-serde"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704b1aeb7be0d0a84fc9828cae51dab5970fee5088f83d1dd7ee6f6246fc6ff1"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
+ "serde",
+ "serde_json",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+ "tracing-serde",
 ]
 
 [[package]]
@@ -2719,6 +2805,12 @@ dependencies = [
  "serde_core",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "vcpkg"

--- a/README.md
+++ b/README.md
@@ -255,7 +255,17 @@ All config values can be overridden via environment variables with the `PENNY_` 
 ```bash
 PENNY_SERVER_BIND=0.0.0.0:8585
 PENNY_DEFAULTS_MODEL=claude-opus-4-1
+PENNY_LOG=info,penny_proxy=debug
+PENNY_OBSERVE_JSON=true
 ```
+
+Observability defaults:
+
+- log filter: `info,sqlx=warn,hyper=warn,reqwest=warn`
+- JSON logs: disabled by default
+- override filter with `PENNY_LOG` (or `RUST_LOG`)
+- override JSON mode with `PENNY_OBSERVE_JSON=true|false|1|0|yes|no|on|off`
+- runtime flags: `--log-filter <RUST_LOG syntax>` and `--json-log`
 
 `pennyprompt serve` bind behavior:
 
@@ -277,7 +287,7 @@ pennyprompt prices update          # Import bundled local pricebook files
 ## CLI Reference
 
 ```
-pennyprompt
+pennyprompt [--log-filter <filter>] [--json-log]
 ├── init [--preset indie|team|explore]     Setup wizard
 ├── serve [--mock] [--proxy-bind] [--admin-bind]  Start proxy + admin
 ├── estimate [--model M] [--context-files]  Pre-execution cost estimate

--- a/crates/penny-cli/Cargo.toml
+++ b/crates/penny-cli/Cargo.toml
@@ -11,6 +11,7 @@ comfy-table = "7"
 glob = "0.3"
 penny-cost = { path = "../penny-cost" }
 penny-config = { path = "../penny-config" }
+penny-observe = { path = "../penny-observe" }
 penny-store = { path = "../penny-store" }
 penny-types = { path = "../penny-types" }
 penny-admin = { path = "../penny-admin" }

--- a/crates/penny-cli/src/main.rs
+++ b/crates/penny-cli/src/main.rs
@@ -19,6 +19,7 @@ use penny_config::{
 };
 use penny_cost::{estimate_tokens, import_pricebook_files, PricingEngine};
 use penny_detect::DetectEngine;
+use penny_observe::ObserveConfig;
 use penny_providers::{
     AnthropicProvider, AnthropicProviderConfig, MockProvider, MockProviderConfig, OpenAiProvider,
     OpenAiProviderConfig, ProviderAdapter,
@@ -45,6 +46,10 @@ const PRICEBOOK_OPENAI_TOML: &str = include_str!("../../../prices/openai.toml");
 struct Cli {
     #[arg(long)]
     database: Option<PathBuf>,
+    #[arg(long, global = true)]
+    log_filter: Option<String>,
+    #[arg(long, global = true, default_value_t = false)]
+    json_log: bool,
     #[command(subcommand)]
     command: Commands,
 }
@@ -512,6 +517,8 @@ struct DetectSessionAlert {
 enum CliError {
     #[error("config error: {0}")]
     Config(String),
+    #[error("observe error: {0}")]
+    Observe(String),
     #[error("store error: {0}")]
     Store(String),
     #[error("cost error: {0}")]
@@ -556,6 +563,7 @@ async fn main() {
 }
 
 async fn run(cli: Cli) -> Result<(), CliError> {
+    init_runtime_tracing(&cli)?;
     let store = open_store(cli.database).await?;
     match cli.command {
         Commands::Init { preset, force } => {
@@ -711,6 +719,17 @@ async fn run(cli: Cli) -> Result<(), CliError> {
         }
     }
     Ok(())
+}
+
+fn init_runtime_tracing(cli: &Cli) -> Result<(), CliError> {
+    let mut observe = ObserveConfig::default();
+    if let Some(filter) = cli.log_filter.as_ref() {
+        observe.log_filter = filter.clone();
+    }
+    if cli.json_log {
+        observe.json = true;
+    }
+    penny_observe::init_tracing(&observe).map_err(|error| CliError::Observe(error.to_string()))
 }
 
 fn run_init(preset: &str, force: bool) -> Result<(), CliError> {

--- a/crates/penny-observe/Cargo.toml
+++ b/crates/penny-observe/Cargo.toml
@@ -5,4 +5,9 @@ edition = "2021"
 publish = false
 
 [dependencies]
+serde = { version = "1", features = ["derive"] }
+thiserror = "1"
+tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt", "json"] }
 
+[dev-dependencies]
+toml = "0.8"

--- a/crates/penny-observe/src/lib.rs
+++ b/crates/penny-observe/src/lib.rs
@@ -1,1 +1,142 @@
 //! Observability setup and tracing helpers.
+
+use std::env;
+
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+use tracing_subscriber::{fmt, layer::SubscriberExt, util::SubscriberInitExt, EnvFilter};
+
+pub const DEFAULT_LOG_FILTER: &str = "info,sqlx=warn,hyper=warn,reqwest=warn";
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ObserveConfig {
+    /// Log level filter (RUST_LOG syntax).
+    #[serde(default = "default_log_filter")]
+    pub log_filter: String,
+    /// Emit JSON logs when enabled.
+    #[serde(default)]
+    pub json: bool,
+}
+
+impl Default for ObserveConfig {
+    fn default() -> Self {
+        Self {
+            log_filter: default_log_filter(),
+            json: false,
+        }
+    }
+}
+
+#[derive(Debug, Error)]
+pub enum InitError {
+    #[error("invalid tracing filter `{filter}`: {source}")]
+    InvalidFilter {
+        filter: String,
+        #[source]
+        source: tracing_subscriber::filter::ParseError,
+    },
+    #[error("tracing already initialized: {0}")]
+    AlreadyInitialized(#[from] tracing_subscriber::util::TryInitError),
+}
+
+pub fn default_log_filter() -> String {
+    DEFAULT_LOG_FILTER.to_string()
+}
+
+/// Initializes global tracing exactly once for the process.
+///
+/// Resolution order:
+/// 1. `PENNY_LOG` (if set and non-empty)
+/// 2. `RUST_LOG` (if set and non-empty)
+/// 3. `cfg.log_filter`
+///
+/// Structured mode can be toggled with `PENNY_OBSERVE_JSON=true|false|1|0|yes|no|on|off`.
+pub fn init_tracing(cfg: &ObserveConfig) -> Result<(), InitError> {
+    let filter_spec = env_filter_override().unwrap_or_else(|| cfg.log_filter.clone());
+    let env_filter =
+        EnvFilter::try_new(filter_spec.clone()).map_err(|source| InitError::InvalidFilter {
+            filter: filter_spec,
+            source,
+        })?;
+    let json = env_json_override().unwrap_or(cfg.json);
+    let registry = tracing_subscriber::registry().with(env_filter);
+
+    if json {
+        registry.with(fmt::layer().json()).try_init()?;
+    } else {
+        registry.with(fmt::layer().with_target(false)).try_init()?;
+    }
+    Ok(())
+}
+
+fn env_filter_override() -> Option<String> {
+    non_empty_env("PENNY_LOG").or_else(|| non_empty_env("RUST_LOG"))
+}
+
+fn env_json_override() -> Option<bool> {
+    non_empty_env("PENNY_OBSERVE_JSON").and_then(|raw| parse_bool(&raw))
+}
+
+fn non_empty_env(key: &str) -> Option<String> {
+    env::var(key)
+        .ok()
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+}
+
+fn parse_bool(value: &str) -> Option<bool> {
+    match value.trim().to_ascii_lowercase().as_str() {
+        "1" | "true" | "yes" | "on" => Some(true),
+        "0" | "false" | "no" | "off" => Some(false),
+        _ => None,
+    }
+}
+
+/// Canonical field names for structured log attributes.
+pub mod fields {
+    pub const REQUEST_ID: &str = "request_id";
+    pub const SESSION_ID: &str = "session_id";
+    pub const PROJECT_ID: &str = "project_id";
+    pub const MODEL: &str = "model";
+    pub const COST_USD: &str = "cost_usd";
+    pub const EVENT_TYPE: &str = "event_type";
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::{Mutex, OnceLock};
+
+    fn env_lock() -> &'static Mutex<()> {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(()))
+    }
+
+    #[test]
+    fn observe_config_toml_roundtrip() {
+        let cfg = ObserveConfig {
+            log_filter: "debug,penny_proxy=trace".to_string(),
+            json: true,
+        };
+        let raw = toml::to_string(&cfg).expect("serialize");
+        let decoded: ObserveConfig = toml::from_str(&raw).expect("deserialize");
+        assert_eq!(decoded, cfg);
+    }
+
+    #[test]
+    fn init_tracing_second_call_returns_already_initialized() {
+        let _guard = env_lock().lock().expect("env lock");
+        std::env::remove_var("PENNY_LOG");
+        std::env::remove_var("RUST_LOG");
+        std::env::remove_var("PENNY_OBSERVE_JSON");
+
+        let first = init_tracing(&ObserveConfig::default());
+        assert!(first.is_ok(), "first init should succeed: {first:?}");
+
+        let second = init_tracing(&ObserveConfig::default());
+        assert!(
+            matches!(second, Err(InitError::AlreadyInitialized(_))),
+            "expected AlreadyInitialized, got {second:?}"
+        );
+    }
+}

--- a/docs/CONFIG-REFERENCE.md
+++ b/docs/CONFIG-REFERENCE.md
@@ -110,6 +110,11 @@ Preset budgets are tagged internally with `preset:<name>` when applied.
 - `PENNY_CLEANUP_STRIP_ANSI` (`true|false|1|0|yes|no|on|off`)
 - `PENNY_CLEANUP_MINIFY_JSON` (`true|false|1|0|yes|no|on|off`)
 
+Observability runtime controls (applied by `penny-observe` at process startup):
+
+- `PENNY_LOG` (RUST_LOG filter syntax, fallback to `RUST_LOG`)
+- `PENNY_OBSERVE_JSON` (`true|false|1|0|yes|no|on|off`)
+
 ## Example Minimal Config
 
 ```toml


### PR DESCRIPTION
## Summary
- implement penny-observe tracing bootstrap with configurable filter/json mode
- initialize tracing from a single CLI startup entrypoint
- add canonical structured field names (request_id, session_id, project_id, model, cost_usd, event_type)
- document env/runtime controls for observability

## Validation
- cargo fmt --all
- cargo test --workspace
- cargo check --workspace
- cargo clippy --workspace --all-targets -- -D warnings

Closes #134