### PR TITLE
docs(release): reconcile alpha release history and artifact claims

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Upcoming changes are tracked via issue-first workflow and merged through PRs.
 - Alpha.2 release gate artifacts: targeted checklist, linked release process gate, and draft release notes template.
 
-## [v0.1.0-alpha.1] - 2026-04-18
+## [v0.1.0-alpha.1] - 2026-04-18 (internal milestone cut; public GitHub Release artifacts not yet reconciled)
 
 ### Added
 - Core M1-M5 foundation: config loading, store/migrations, pricing engine, proxy plane, atomic budget/ledger flow, detect heuristics, and operator CLI commands.

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -10,16 +10,16 @@ This document describes alpha installation paths for PennyPrompt.
 
 ## 2. Quick Install from GitHub Release (`curl | sh`)
 
-Install latest alpha release:
+Install from the latest published GitHub Release (when available):
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/manuelpenazuniga/PennyPrompt/main/scripts/install.sh | sh
 ```
 
-Install specific version:
+Install specific published tag:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/manuelpenazuniga/PennyPrompt/main/scripts/install.sh | PENNY_VERSION=v0.1.0-alpha.1 sh
+curl -fsSL https://raw.githubusercontent.com/manuelpenazuniga/PennyPrompt/main/scripts/install.sh | PENNY_VERSION=<published-tag> sh
 ```
 
 By default the binary is installed to:

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -7,6 +7,7 @@ This document defines the repeatable process for alpha releases.
 - Generic alpha manual checklist: [`docs/ALPHA-MANUAL-CHECKLIST.md`](./ALPHA-MANUAL-CHECKLIST.md)
 - Targeted gate for current cut: [`docs/RELEASE_GATE_v0.1.0-alpha.2.md`](./RELEASE_GATE_v0.1.0-alpha.2.md)
 - Release notes draft for current cut: [`docs/release-notes/v0.1.0-alpha.2.md`](./release-notes/v0.1.0-alpha.2.md)
+- Release history reconciliation note: [`docs/release-audit/2026-04-30-release-history-reconciliation.md`](./release-audit/2026-04-30-release-history-reconciliation.md)
 
 ## Scope
 
@@ -17,7 +18,7 @@ Current release automation builds and publishes `penny-cli` binaries for:
 - macOS `x86_64-apple-darwin`
 - macOS `aarch64-apple-darwin`
 
-All artifacts are published as `.tar.gz` plus SHA-256 checksums.
+When a release tag is pushed and the workflow succeeds, artifacts are published as `.tar.gz` plus SHA-256 checksums.
 
 ## Workflow Trigger
 
@@ -29,7 +30,7 @@ Release workflow file:
 
 Trigger condition:
 
-- push a tag that starts with `v` (example: `v0.1.0-alpha.1`)
+- push a tag that starts with `v` (example: `v0.1.0-alpha.2`)
 
 Manual trigger is also available via `workflow_dispatch`.
 
@@ -76,7 +77,7 @@ scripts/install.sh
 
 Supported env vars:
 
-- `PENNY_VERSION` (example: `v0.1.0-alpha.1`)
+- `PENNY_VERSION` (example: `v0.1.0-alpha.2`)
 - `PENNY_INSTALL_DIR` (default: `~/.local/bin`)
 - `PENNY_REPO` (default: `manuelpenazuniga/PennyPrompt`)
 

--- a/docs/release-audit/2026-04-30-release-history-reconciliation.md
+++ b/docs/release-audit/2026-04-30-release-history-reconciliation.md
@@ -1,0 +1,30 @@
+# Release History Reconciliation (2026-04-30)
+
+Issue: #143
+
+## Purpose
+
+Reconcile documented alpha release history with observable GitHub artifacts.
+
+## Observed GitHub State (2026-04-30)
+
+The following checks were executed against the repository:
+
+- `gh release list --limit 20`
+- `gh run list --workflow release.yml --limit 20`
+- `git ls-remote --tags origin`
+
+Observed output at audit time: no rows returned for releases, release workflow runs, or remote tags.
+
+## Reconciliation Decision
+
+1. `v0.1.0-alpha.1` remains recorded in `CHANGELOG.md` as an internal milestone cut date.
+2. `v0.1.0-alpha.1` is not treated as a publicly verifiable GitHub Release artifact unless tag/release assets are later published.
+3. Release and installation docs must avoid wording that implies a published artifact exists when none is observable.
+4. Canonical public release history is defined by observable GitHub tags + GitHub Releases.
+
+## Follow-up Execution
+
+- #144 will execute and evidence the `v0.1.0-alpha.2` gate.
+- #145 will finalize alpha.2 notes and changelog release entry.
+


### PR DESCRIPTION
## Summary
- add a dated release reconciliation note under docs/release-audit
- document observed GitHub state for releases, release workflow runs, and remote tags
- update release/install wording to avoid implying published artifacts where none are observable
- annotate changelog alpha.1 entry as internal milestone pending public artifact reconciliation

## Validation
- docs-only change; no code path modified

Closes #143