### PR TITLE
docs(release): finalize v0.1.0-alpha.2 notes and changelog cut

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,19 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 - Upcoming changes are tracked via issue-first workflow and merged through PRs.
-- Alpha.2 release gate artifacts: targeted checklist, linked release process gate, and draft release notes template.
+- Alpha.2 release gate artifacts: targeted checklist, linked release process gate, and release notes document.
+
+## [v0.1.0-alpha.2] - 2026-04-30 (release publication pending under #144)
+
+### Added
+- `penny-cli serve` runtime lifecycle with proxy/admin startup and graceful shutdown flow (`#129`).
+- Operator/docs command-surface alignment for serve/admin/tail/detect semantics (`#130`).
+- Refreshed local pricebooks with default-model resolvability guardrail (`#131`).
+- Tracing bootstrap via `penny-observe` integrated into CLI startup path (`#134`).
+- Release gate and notes artifacts for auditable alpha.2 publication workflow (`#132`).
+
+### Changed
+- Release/install documentation now avoids unverifiable artifact publication claims and links to explicit reconciliation notes (`#143`).
 
 ## [v0.1.0-alpha.1] - 2026-04-18 (internal milestone cut; public GitHub Release artifacts not yet reconciled)
 

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -6,7 +6,7 @@ This document defines the repeatable process for alpha releases.
 
 - Generic alpha manual checklist: [`docs/ALPHA-MANUAL-CHECKLIST.md`](./ALPHA-MANUAL-CHECKLIST.md)
 - Targeted gate for current cut: [`docs/RELEASE_GATE_v0.1.0-alpha.2.md`](./RELEASE_GATE_v0.1.0-alpha.2.md)
-- Release notes draft for current cut: [`docs/release-notes/v0.1.0-alpha.2.md`](./release-notes/v0.1.0-alpha.2.md)
+- Release notes for current cut: [`docs/release-notes/v0.1.0-alpha.2.md`](./release-notes/v0.1.0-alpha.2.md)
 - Release history reconciliation note: [`docs/release-audit/2026-04-30-release-history-reconciliation.md`](./release-audit/2026-04-30-release-history-reconciliation.md)
 
 ## Scope
@@ -38,7 +38,7 @@ Manual trigger is also available via `workflow_dispatch`.
 
 1. Ensure `main` is green and synchronized.
 2. Complete the active release gate checklist (`RELEASE_GATE_v0.1.0-alpha.2.md` for alpha.2).
-3. Update `CHANGELOG.md` and finalize release notes draft.
+3. Update `CHANGELOG.md` and finalize release notes.
 4. Confirm release notes include resolved blocking issues and known limitations link.
 5. Create and push a tag:
 

--- a/docs/release-notes/v0.1.0-alpha.2.md
+++ b/docs/release-notes/v0.1.0-alpha.2.md
@@ -1,4 +1,6 @@
-# PennyPrompt v0.1.0-alpha.2 (Draft Notes)
+# PennyPrompt v0.1.0-alpha.2
+
+Publication status: release notes finalized; GitHub Release publication is tracked in #144.
 
 ## Summary
 


### PR DESCRIPTION
## Summary
- finalize alpha.2 release notes document (remove draft state)
- add formal v0.1.0-alpha.2 changelog section with aligned issue references
- update release process wording to reference finalized notes

## Validation
- docs-only change; no runtime or build behavior modified

Closes #145