### PR TITLE
fix(admin): make hostname/ip admin bind contract explicit and testable

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,7 +271,7 @@ Observability defaults:
 
 - Proxy plane binds to `server.bind` (default `127.0.0.1:8585`).
 - Admin plane reads `server.admin_socket`.
-- If `admin_socket` is `host:port`, admin binds TCP.
+- If `admin_socket` is `host:port` (for example `localhost:8586` or `127.0.0.1:8586`), admin binds TCP.
 - Otherwise admin binds a Unix socket path (supports `~` expansion).
 - You can override at runtime with `--proxy-bind` and `--admin-bind`.
 

--- a/crates/penny-admin/src/lib.rs
+++ b/crates/penny-admin/src/lib.rs
@@ -1344,7 +1344,9 @@ mod tests {
     #[test]
     fn classify_bind_target_accepts_unix_socket_path() {
         let target = classify_bind_target("/tmp/pennyprompt-admin.sock").expect("bind target");
-        assert!(matches!(target, BindTarget::Unix(path) if path.as_path() == std::path::Path::new("/tmp/pennyprompt-admin.sock")));
+        assert!(
+            matches!(target, BindTarget::Unix(path) if path.as_path() == std::path::Path::new("/tmp/pennyprompt-admin.sock"))
+        );
     }
 
     #[test]

--- a/crates/penny-admin/src/lib.rs
+++ b/crates/penny-admin/src/lib.rs
@@ -342,42 +342,82 @@ pub async fn serve_with_shutdown<F>(
 where
     F: Future<Output = ()> + Send + 'static,
 {
-    if let Ok(addr) = bind.parse::<SocketAddr>() {
-        let listener = TcpListener::bind(addr).await?;
-        let app = build_router(state);
-        axum::serve(listener, app)
-            .with_graceful_shutdown(shutdown)
-            .await?;
-        return Ok(());
-    }
+    let bind_target = classify_bind_target(bind)?;
 
-    #[cfg(unix)]
-    {
-        let socket_path = normalize_unix_socket_path(bind)?;
-        let listener = bind_unix_listener(&socket_path)?;
-        let app = build_router(state);
-        let result = axum::serve(listener, app)
-            .with_graceful_shutdown(shutdown)
-            .await;
-        cleanup_unix_socket(&socket_path)?;
-        result?;
-        Ok(())
-    }
+    match bind_target {
+        BindTarget::Tcp(bind_addr) => {
+            let listener = TcpListener::bind(&bind_addr).await?;
+            let app = build_router(state);
+            axum::serve(listener, app)
+                .with_graceful_shutdown(shutdown)
+                .await?;
+            Ok(())
+        }
 
-    #[cfg(not(unix))]
-    {
-        let _ = (state, shutdown);
-        Err(AdminError::InvalidBind(bind.to_string()))
+        #[cfg(unix)]
+        BindTarget::Unix(socket_path) => {
+            let listener = bind_unix_listener(&socket_path)?;
+            let app = build_router(state);
+            let result = axum::serve(listener, app)
+                .with_graceful_shutdown(shutdown)
+                .await;
+            cleanup_unix_socket(&socket_path)?;
+            result?;
+            Ok(())
+        }
     }
 }
 
-#[cfg(unix)]
-fn normalize_unix_socket_path(raw: &str) -> Result<PathBuf, AdminError> {
+enum BindTarget {
+    Tcp(String),
+    #[cfg(unix)]
+    Unix(PathBuf),
+}
+
+fn classify_bind_target(raw: &str) -> Result<BindTarget, AdminError> {
     let trimmed = raw.trim();
     if trimmed.is_empty() {
         return Err(AdminError::InvalidBind(raw.to_string()));
     }
-    Ok(PathBuf::from(trimmed))
+    if trimmed.parse::<SocketAddr>().is_ok() || is_host_port_candidate(trimmed) {
+        return Ok(BindTarget::Tcp(trimmed.to_string()));
+    }
+
+    #[cfg(unix)]
+    {
+        // Reject colon-delimited non-path values (for example, localhost:notaport)
+        // so they do not silently fall through to Unix socket binding.
+        if trimmed.contains(':') && !trimmed.contains('/') {
+            return Err(AdminError::InvalidBind(raw.to_string()));
+        }
+        Ok(BindTarget::Unix(PathBuf::from(trimmed)))
+    }
+
+    #[cfg(not(unix))]
+    {
+        return Err(AdminError::InvalidBind(raw.to_string()));
+    }
+}
+
+fn is_host_port_candidate(value: &str) -> bool {
+    if value.contains('/') {
+        return false;
+    }
+    if value.starts_with('[') {
+        let Some(bracket_end) = value.find(']') else {
+            return false;
+        };
+        if value.get(bracket_end + 1..bracket_end + 2) != Some(":") {
+            return false;
+        }
+        return value[bracket_end + 2..].parse::<u16>().is_ok();
+    }
+    let Some(separator) = value.rfind(':') else {
+        return false;
+    };
+    let host = &value[..separator];
+    let port = &value[separator + 1..];
+    !host.is_empty() && port.parse::<u16>().is_ok()
 }
 
 #[cfg(unix)]
@@ -1286,6 +1326,39 @@ mod tests {
         SqliteStore::connect("sqlite::memory:")
             .await
             .expect("create in-memory store")
+    }
+
+    #[test]
+    fn classify_bind_target_accepts_ip_port() {
+        let target = classify_bind_target("127.0.0.1:8586").expect("bind target");
+        assert!(matches!(target, BindTarget::Tcp(addr) if addr == "127.0.0.1:8586"));
+    }
+
+    #[test]
+    fn classify_bind_target_accepts_hostname_port() {
+        let target = classify_bind_target("localhost:8586").expect("bind target");
+        assert!(matches!(target, BindTarget::Tcp(addr) if addr == "localhost:8586"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn classify_bind_target_accepts_unix_socket_path() {
+        let target = classify_bind_target("/tmp/pennyprompt-admin.sock").expect("bind target");
+        assert!(matches!(target, BindTarget::Unix(path) if path.as_path() == std::path::Path::new("/tmp/pennyprompt-admin.sock")));
+    }
+
+    #[test]
+    fn classify_bind_target_rejects_invalid_colon_bind() {
+        let result = classify_bind_target("localhost:notaport");
+        assert!(matches!(result, Err(AdminError::InvalidBind(_))));
+    }
+
+    #[tokio::test]
+    async fn serve_with_shutdown_rejects_invalid_colon_bind() {
+        let store = setup_store().await;
+        let state = AdminState::new(store);
+        let result = serve_with_shutdown("localhost:notaport", state, async {}).await;
+        assert!(matches!(result, Err(AdminError::InvalidBind(_))));
     }
 
     async fn seed_minimal_data(store: &SqliteStore) {

--- a/crates/penny-cli/src/main.rs
+++ b/crates/penny-cli/src/main.rs
@@ -1347,11 +1347,32 @@ fn map_admin_task(
 }
 
 fn admin_bind_display(bind: &str) -> String {
-    if bind.parse::<std::net::SocketAddr>().is_ok() {
+    if bind.parse::<std::net::SocketAddr>().is_ok() || is_host_port_candidate(bind) {
         format!("http://{bind}")
     } else {
         format!("unix://{bind}")
     }
+}
+
+fn is_host_port_candidate(value: &str) -> bool {
+    if value.contains('/') {
+        return false;
+    }
+    if value.starts_with('[') {
+        let Some(bracket_end) = value.find(']') else {
+            return false;
+        };
+        if value.get(bracket_end + 1..bracket_end + 2) != Some(":") {
+            return false;
+        }
+        return value[bracket_end + 2..].parse::<u16>().is_ok();
+    }
+    let Some(separator) = value.rfind(':') else {
+        return false;
+    };
+    let host = &value[..separator];
+    let port = &value[separator + 1..];
+    !host.is_empty() && port.parse::<u16>().is_ok()
 }
 
 #[cfg(unix)]
@@ -3752,6 +3773,25 @@ mod tests {
     fn check_admin_bind_readiness_accepts_ephemeral_tcp_bind() {
         let readiness = check_admin_bind_readiness("127.0.0.1:0");
         assert!(readiness.ok, "readiness detail: {}", readiness.detail);
+    }
+
+    #[test]
+    fn admin_bind_display_supports_hostname_tcp_targets() {
+        assert_eq!(
+            admin_bind_display("localhost:8586"),
+            "http://localhost:8586"
+        );
+        assert_eq!(
+            admin_bind_display("127.0.0.1:8586"),
+            "http://127.0.0.1:8586"
+        );
+    }
+
+    #[test]
+    fn host_port_candidate_rejects_unix_paths_and_invalid_ports() {
+        assert!(is_host_port_candidate("localhost:8586"));
+        assert!(!is_host_port_candidate("/tmp/penny-admin.sock"));
+        assert!(!is_host_port_candidate("localhost:notaport"));
     }
 
     #[test]

--- a/docs/CONFIG-REFERENCE.md
+++ b/docs/CONFIG-REFERENCE.md
@@ -33,7 +33,7 @@ Config is resolved in this order (later overrides earlier):
 
 - `bind` (`string`): proxy bind address (example `127.0.0.1:8585`)
 - `admin_socket` (`string`): admin bind target
-  - if value is `host:port`, admin binds TCP
+  - if value is `host:port` (for example `localhost:8586` or `127.0.0.1:8586`), admin binds TCP
   - otherwise admin binds a Unix socket path
 - `database_path` (`string`): SQLite database path
 - `mode` (`observe|guard`)


### PR DESCRIPTION
## Summary
- classify admin bind targets explicitly as TCP (ip:port or hostname:port) vs Unix socket paths
- prevent invalid colon-delimited values (for example localhost:notaport) from silently falling back to Unix socket binding
- ensure penny-cli serve bind display treats hostname:port as TCP
- add coverage for ip:port, hostname:port, unix path, and invalid bind cases
- align README and CONFIG-REFERENCE wording with the runtime contract

## Validation
- cargo fmt --all
- cargo test -p penny-admin --locked
- cargo test -p penny-cli --locked
- cargo check --workspace --locked
- cargo clippy -p penny-admin -p penny-cli --all-targets --locked -- -D warnings

Closes #146