### PR TITLE
fix(observe): enforce CLI-over-env precedence for runtime logging controls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Upcoming changes are tracked via issue-first workflow and merged through PRs.
 - Alpha.2 release gate artifacts: targeted checklist, linked release process gate, and release notes document.
 
+### Changed
+- Observability startup precedence is now explicit: CLI flags (`--log-filter`, `--json-log`) override environment (`PENNY_LOG`/`RUST_LOG`, `PENNY_OBSERVE_JSON`), which still override built-in defaults. Backward-compatibility note: workflows relying on env vars to force logging behavior should stop passing conflicting CLI flags.
+
 ## [v0.1.0-alpha.2] - 2026-04-30 (release publication pending under #144)
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -263,8 +263,9 @@ Observability defaults:
 
 - log filter: `info,sqlx=warn,hyper=warn,reqwest=warn`
 - JSON logs: disabled by default
-- override filter with `PENNY_LOG` (or `RUST_LOG`)
-- override JSON mode with `PENNY_OBSERVE_JSON=true|false|1|0|yes|no|on|off`
+- precedence: explicit CLI flags > environment > built-in defaults
+- filter env override: `PENNY_LOG` (fallback `RUST_LOG`)
+- JSON env override: `PENNY_OBSERVE_JSON=true|false|1|0|yes|no|on|off`
 - runtime flags: `--log-filter <RUST_LOG syntax>` and `--json-log`
 
 `pennyprompt serve` bind behavior:

--- a/crates/penny-cli/src/main.rs
+++ b/crates/penny-cli/src/main.rs
@@ -19,7 +19,7 @@ use penny_config::{
 };
 use penny_cost::{estimate_tokens, import_pricebook_files, PricingEngine};
 use penny_detect::DetectEngine;
-use penny_observe::ObserveConfig;
+use penny_observe::{ObserveConfig, ObserveRuntimeOverrides};
 use penny_providers::{
     AnthropicProvider, AnthropicProviderConfig, MockProvider, MockProviderConfig, OpenAiProvider,
     OpenAiProviderConfig, ProviderAdapter,
@@ -722,14 +722,21 @@ async fn run(cli: Cli) -> Result<(), CliError> {
 }
 
 fn init_runtime_tracing(cli: &Cli) -> Result<(), CliError> {
-    let mut observe = ObserveConfig::default();
-    if let Some(filter) = cli.log_filter.as_ref() {
-        observe.log_filter = filter.clone();
+    let observe = ObserveConfig::default();
+    let overrides = observe_runtime_overrides_from_cli(cli);
+    penny_observe::init_tracing_with_overrides(&observe, &overrides)
+        .map_err(|error| CliError::Observe(error.to_string()))
+}
+
+fn observe_runtime_overrides_from_cli(cli: &Cli) -> ObserveRuntimeOverrides {
+    ObserveRuntimeOverrides {
+        log_filter: cli
+            .log_filter
+            .as_ref()
+            .map(|value| value.trim().to_string())
+            .filter(|value| !value.is_empty()),
+        json: cli.json_log.then_some(true),
     }
-    if cli.json_log {
-        observe.json = true;
-    }
-    penny_observe::init_tracing(&observe).map_err(|error| CliError::Observe(error.to_string()))
 }
 
 fn run_init(preset: &str, force: bool) -> Result<(), CliError> {
@@ -3254,6 +3261,7 @@ mod tests {
     use std::fs;
     use std::net::TcpListener as StdTcpListener;
     use std::path::Path;
+    use std::sync::{Mutex, OnceLock};
 
     use chrono::{Duration as ChronoDuration, TimeZone};
     use penny_store::{
@@ -3268,6 +3276,20 @@ mod tests {
         SqliteStore::connect("sqlite::memory:")
             .await
             .expect("create in-memory store")
+    }
+
+    fn env_lock() -> &'static Mutex<()> {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(()))
+    }
+
+    fn test_cli(log_filter: Option<&str>, json_log: bool) -> Cli {
+        Cli {
+            database: None,
+            log_filter: log_filter.map(str::to_string),
+            json_log,
+            command: Commands::Doctor,
+        }
     }
 
     fn find_free_port() -> u16 {
@@ -3408,6 +3430,36 @@ mod tests {
         assert!(parse_since_duration("xyz").is_err());
         assert!(parse_since_duration("10").is_err());
         assert!(parse_since_duration("3w").is_err());
+    }
+
+    #[test]
+    fn observe_runtime_overrides_cli_log_filter_beats_env() {
+        let _guard = env_lock().lock().expect("env lock");
+        std::env::set_var("PENNY_LOG", "warn");
+        std::env::remove_var("RUST_LOG");
+        std::env::remove_var("PENNY_OBSERVE_JSON");
+
+        let cli = test_cli(Some("trace,penny_proxy=debug"), false);
+        let resolved = penny_observe::resolve_observe_config(
+            &ObserveConfig::default(),
+            &observe_runtime_overrides_from_cli(&cli),
+        );
+        assert_eq!(resolved.log_filter, "trace,penny_proxy=debug");
+    }
+
+    #[test]
+    fn observe_runtime_overrides_cli_json_flag_beats_env_false() {
+        let _guard = env_lock().lock().expect("env lock");
+        std::env::set_var("PENNY_OBSERVE_JSON", "false");
+        std::env::remove_var("PENNY_LOG");
+        std::env::remove_var("RUST_LOG");
+
+        let cli = test_cli(None, true);
+        let resolved = penny_observe::resolve_observe_config(
+            &ObserveConfig::default(),
+            &observe_runtime_overrides_from_cli(&cli),
+        );
+        assert!(resolved.json);
     }
 
     #[test]

--- a/crates/penny-observe/src/lib.rs
+++ b/crates/penny-observe/src/lib.rs
@@ -18,6 +18,12 @@ pub struct ObserveConfig {
     pub json: bool,
 }
 
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct ObserveRuntimeOverrides {
+    pub log_filter: Option<String>,
+    pub json: Option<bool>,
+}
+
 impl Default for ObserveConfig {
     fn default() -> Self {
         Self {
@@ -52,13 +58,23 @@ pub fn default_log_filter() -> String {
 ///
 /// Structured mode can be toggled with `PENNY_OBSERVE_JSON=true|false|1|0|yes|no|on|off`.
 pub fn init_tracing(cfg: &ObserveConfig) -> Result<(), InitError> {
-    let filter_spec = env_filter_override().unwrap_or_else(|| cfg.log_filter.clone());
+    init_tracing_with_overrides(cfg, &ObserveRuntimeOverrides::default())
+}
+
+/// Initializes global tracing exactly once for the process, allowing explicit
+/// runtime overrides (for example, CLI flags) to take precedence over env vars.
+pub fn init_tracing_with_overrides(
+    cfg: &ObserveConfig,
+    overrides: &ObserveRuntimeOverrides,
+) -> Result<(), InitError> {
+    let resolved = resolve_observe_config(cfg, overrides);
+    let filter_spec = resolved.log_filter;
     let env_filter =
         EnvFilter::try_new(filter_spec.clone()).map_err(|source| InitError::InvalidFilter {
             filter: filter_spec,
             source,
         })?;
-    let json = env_json_override().unwrap_or(cfg.json);
+    let json = resolved.json;
     let registry = tracing_subscriber::registry().with(env_filter);
 
     if json {
@@ -67,6 +83,30 @@ pub fn init_tracing(cfg: &ObserveConfig) -> Result<(), InitError> {
         registry.with(fmt::layer().with_target(false)).try_init()?;
     }
     Ok(())
+}
+
+/// Resolves effective observe config without initializing tracing.
+///
+/// Resolution order:
+/// 1. explicit runtime overrides
+/// 2. environment (`PENNY_LOG`/`RUST_LOG`, `PENNY_OBSERVE_JSON`)
+/// 3. base config values
+pub fn resolve_observe_config(
+    cfg: &ObserveConfig,
+    overrides: &ObserveRuntimeOverrides,
+) -> ObserveConfig {
+    let log_filter = overrides
+        .log_filter
+        .as_ref()
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+        .or_else(env_filter_override)
+        .unwrap_or_else(|| cfg.log_filter.clone());
+    let json = overrides
+        .json
+        .or_else(env_json_override)
+        .unwrap_or(cfg.json);
+    ObserveConfig { log_filter, json }
 }
 
 fn env_filter_override() -> Option<String> {
@@ -138,5 +178,43 @@ mod tests {
             matches!(second, Err(InitError::AlreadyInitialized(_))),
             "expected AlreadyInitialized, got {second:?}"
         );
+    }
+
+    #[test]
+    fn resolve_observe_config_prefers_runtime_overrides_over_env() {
+        let _guard = env_lock().lock().expect("env lock");
+        std::env::set_var("PENNY_LOG", "warn");
+        std::env::set_var("PENNY_OBSERVE_JSON", "false");
+
+        let base = ObserveConfig {
+            log_filter: "info".to_string(),
+            json: false,
+        };
+        let resolved = resolve_observe_config(
+            &base,
+            &ObserveRuntimeOverrides {
+                log_filter: Some("trace,penny_proxy=debug".to_string()),
+                json: Some(true),
+            },
+        );
+
+        assert_eq!(resolved.log_filter, "trace,penny_proxy=debug");
+        assert!(resolved.json);
+    }
+
+    #[test]
+    fn resolve_observe_config_uses_env_when_runtime_overrides_absent() {
+        let _guard = env_lock().lock().expect("env lock");
+        std::env::set_var("PENNY_LOG", "error");
+        std::env::set_var("PENNY_OBSERVE_JSON", "true");
+
+        let base = ObserveConfig {
+            log_filter: "info".to_string(),
+            json: false,
+        };
+        let resolved = resolve_observe_config(&base, &ObserveRuntimeOverrides::default());
+
+        assert_eq!(resolved.log_filter, "error");
+        assert!(resolved.json);
     }
 }

--- a/docs/CONFIG-REFERENCE.md
+++ b/docs/CONFIG-REFERENCE.md
@@ -112,6 +112,7 @@ Preset budgets are tagged internally with `preset:<name>` when applied.
 
 Observability runtime controls (applied by `penny-observe` at process startup):
 
+- precedence: explicit CLI flags (`--log-filter`, `--json-log`) > environment > defaults
 - `PENNY_LOG` (RUST_LOG filter syntax, fallback to `RUST_LOG`)
 - `PENNY_OBSERVE_JSON` (`true|false|1|0|yes|no|on|off`)
 


### PR DESCRIPTION
## Summary
- add observe runtime override API so explicit runtime values are resolved before env defaults
- wire penny-cli startup tracing to pass explicit CLI overrides (--log-filter, --json-log)
- keep env-driven behavior for non-explicit CLI cases, while making explicit CLI flags authoritative
- add precedence tests for both crates and document policy in README/config reference
- record backward-compatibility note in changelog

## Validation
- cargo fmt --all
- cargo test -p penny-observe --locked
- cargo test -p penny-cli --locked
- cargo check --workspace --locked
- cargo clippy -p penny-observe --all-targets --locked -- -D warnings
- cargo clippy -p penny-cli --all-targets --locked -- -D warnings

Closes #150