### PR TITLE
chore(workflow): enforce issue linkage in PR bodies

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,14 @@
+## Summary
+- 
+
+## Validation
+- [ ] `cargo fmt --all`
+- [ ] `cargo test --workspace --locked`
+- [ ] `cargo check --workspace --locked`
+- [ ] `cargo clippy --workspace --all-targets --locked -- -D warnings`
+
+## Issue Linkage (Required)
+Closes #
+
+## Notes
+- 

--- a/.github/workflows/pr-issue-linkage.yml
+++ b/.github/workflows/pr-issue-linkage.yml
@@ -1,0 +1,36 @@
+name: PR Issue Linkage
+
+on:
+  pull_request_target:
+    types: [opened, edited, reopened, synchronize, labeled, unlabeled]
+
+jobs:
+  enforce-linkage:
+    name: Enforce Closes #N Discipline
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    steps:
+      - name: Validate issue linkage in PR body
+        env:
+          EVENT_PATH: ${{ github.event_path }}
+        run: |
+          set -euo pipefail
+
+          BODY="$(jq -r '.pull_request.body // ""' "$EVENT_PATH")"
+          HAS_SKIP_LABEL="$(jq -r '[.pull_request.labels[]?.name] | any(. == "skip-issue-linkage")' "$EVENT_PATH")"
+
+          if [ "$HAS_SKIP_LABEL" = "true" ]; then
+            echo "skip-issue-linkage label present; bypassing issue linkage enforcement."
+            exit 0
+          fi
+
+          if echo "$BODY" | grep -Eiq '\b(close[sd]?|fix(e[sd])?|resolve[sd]?)\s+([A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+)?#[0-9]+\b'; then
+            echo "Issue linkage check passed."
+            exit 0
+          fi
+
+          echo "PR body must include issue linkage (for example: 'Closes #151')."
+          echo "If this PR intentionally has no issue to close, add label 'skip-issue-linkage' and explain why in PR body."
+          exit 1

--- a/docs/DEVELOPMENT_WORKFLOW.md
+++ b/docs/DEVELOPMENT_WORKFLOW.md
@@ -22,7 +22,8 @@ This is the working protocol we use to keep delivery, traceability, and review q
 2. Create a new branch per issue.
 3. Keep scope strict to that issue only.
 4. Open one PR per branch.
-5. Merge PR, then sync `main` before starting the next issue.
+5. PR body must include an issue-closing keyword (`Closes #N`, `Fixes #N`, or `Resolves #N`).
+6. Merge PR, then sync `main` before starting the next issue.
 
 Recommended branch naming:
 
@@ -50,12 +51,13 @@ cargo check --workspace
 ```
 5. Stage only intended files and commit with issue reference.
 6. Push and open PR.
-7. Review bot/human comments and classify:
+7. Ensure PR body includes issue linkage (`Closes #N` discipline). If a PR intentionally has no linked issue, add label `skip-issue-linkage` and explain why in the PR body.
+8. Review bot/human comments and classify:
 - Must-fix now (functional correctness/security/data integrity).
 - Covered by existing backlog issue.
 - New technical debt issue.
-8. Merge PR.
-9. Sync main again before next issue.
+9. Merge PR.
+10. Sync main again before next issue.
 
 ## Commit Message Pattern
 


### PR DESCRIPTION
## Summary
- require issue linkage keywords in docs/DEVELOPMENT_WORKFLOW.md as part of the branch/PR protocol
- add a repository pull request template with a mandatory Issue Linkage section
- add a CI policy workflow that fails PRs missing a closing keyword reference and supports an explicit skip label for exceptions

## Validation
- cargo fmt --all
- cargo check --workspace --locked

Closes #151