### PR TITLE
docs(cli): align tail/detect UX with admin topology defaults

### DIFF
--- a/.github/workflows/pr-issue-linkage.yml
+++ b/.github/workflows/pr-issue-linkage.yml
@@ -13,13 +13,11 @@ jobs:
       pull-requests: read
     steps:
       - name: Validate issue linkage in PR body
-        env:
-          EVENT_PATH: ${{ github.event_path }}
         run: |
           set -euo pipefail
 
-          BODY="$(jq -r '.pull_request.body // ""' "$EVENT_PATH")"
-          HAS_SKIP_LABEL="$(jq -r '[.pull_request.labels[]?.name] | any(. == "skip-issue-linkage")' "$EVENT_PATH")"
+          BODY="$(jq -r '.pull_request.body // ""' "$GITHUB_EVENT_PATH")"
+          HAS_SKIP_LABEL="$(jq -r '[.pull_request.labels[]?.name] | any(. == "skip-issue-linkage")' "$GITHUB_EVENT_PATH")"
 
           if [ "$HAS_SKIP_LABEL" = "true" ]; then
             echo "skip-issue-linkage label present; bypassing issue linkage enforcement."

--- a/.github/workflows/pr-issue-linkage.yml
+++ b/.github/workflows/pr-issue-linkage.yml
@@ -26,7 +26,8 @@ jobs:
             exit 0
           fi
 
-          if echo "$BODY" | grep -Eiq '\b(close[sd]?|fix(e[sd])?|resolve[sd]?)\s+([A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+)?#[0-9]+\b'; then
+          shopt -s nocasematch
+          if [[ "$BODY" =~ (close[sd]?|fix(e[sd])?|resolve[sd]?)[[:space:]]+([A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+)?#[0-9]+ ]]; then
             echo "Issue linkage check passed."
             exit 0
           fi

--- a/README.md
+++ b/README.md
@@ -151,6 +151,12 @@ Your reports are useful from the first request, zero configuration.
 
 ### Real-Time Monitoring
 
+Start `serve` with admin on loopback TCP (terminal A), then run `tail`/`detect` from terminal B:
+
+```bash
+$ pennyprompt serve --admin-bind 127.0.0.1:8586
+```
+
 ```bash
 $ pennyprompt tail
 
@@ -205,7 +211,8 @@ pennyprompt init --preset explore   # $10/mo soft limit only, observe mode
 
 [server]
 bind = "127.0.0.1:8585"               # Proxy plane
-admin_socket = "~/.local/share/pennyprompt/admin.sock"
+admin_socket = "127.0.0.1:8586"       # Recommended for tail/detect defaults
+# admin_socket = "~/.local/share/pennyprompt/admin.sock"  # Optional unix socket mode
 database_path = "~/.local/share/pennyprompt/penny.db"
 mode = "guard"                          # observe | guard
 
@@ -273,7 +280,8 @@ Observability defaults:
 - Proxy plane binds to `server.bind` (default `127.0.0.1:8585`).
 - Admin plane reads `server.admin_socket`.
 - If `admin_socket` is `host:port` (for example `localhost:8586` or `127.0.0.1:8586`), admin binds TCP.
-- Otherwise admin binds a Unix socket path (supports `~` expansion).
+- `tail` and `detect` defaults expect admin HTTP at `http://127.0.0.1:8586`, so use `--admin-bind 127.0.0.1:8586` or set `server.admin_socket = "127.0.0.1:8586"`.
+- If admin runs on a Unix socket path, `tail`/`detect` require an explicit reachable TCP admin bind.
 - You can override at runtime with `--proxy-bind` and `--admin-bind`.
 
 ### Pricebook
@@ -301,9 +309,9 @@ pennyprompt [--log-filter <filter>] [--json-log]
 │   ├── set <scope> <window> <limit>        Create/update budget
 │   └── reset <scope> <window>              Reset a budget window
 ├── detect
-│   ├── status                              Active alerts, paused sessions
-│   └── resume <session_id>                 Resume paused session
-├── tail                                    Live request + cost stream
+│   ├── status [--admin-url]                Active alerts, paused sessions
+│   └── resume <session_id> [--admin-url]   Resume paused session
+├── tail [--admin-url]                      Live request + cost stream
 ├── doctor                                  System diagnostics
 ├── prices
 │   ├── show                                Current pricebook

--- a/crates/penny-cli/src/main.rs
+++ b/crates/penny-cli/src/main.rs
@@ -113,11 +113,18 @@ enum Commands {
         mock: bool,
         #[arg(long)]
         proxy_bind: Option<String>,
-        #[arg(long)]
+        #[arg(
+            long,
+            help = "Admin bind target. Use 127.0.0.1:8586 for tail/detect defaults; otherwise a unix socket path is used."
+        )]
         admin_bind: Option<String>,
     },
     Tail {
-        #[arg(long, default_value = "http://127.0.0.1:8586")]
+        #[arg(
+            long,
+            default_value = "http://127.0.0.1:8586",
+            help = "Admin HTTP base URL. Defaults to loopback TCP; requires serve --admin-bind 127.0.0.1:8586 (or equivalent)."
+        )]
         admin_url: String,
         #[arg(long)]
         since_id: Option<i64>,
@@ -159,14 +166,22 @@ enum ReportCommands {
 #[derive(Debug, Subcommand)]
 enum DetectCommands {
     Status {
-        #[arg(long, default_value = "http://127.0.0.1:8586")]
+        #[arg(
+            long,
+            default_value = "http://127.0.0.1:8586",
+            help = "Admin HTTP base URL. Defaults to loopback TCP; requires serve --admin-bind 127.0.0.1:8586 (or equivalent)."
+        )]
         admin_url: String,
     },
     Resume {
         session_id: String,
         #[arg(long)]
         request_id: Option<String>,
-        #[arg(long, default_value = "http://127.0.0.1:8586")]
+        #[arg(
+            long,
+            default_value = "http://127.0.0.1:8586",
+            help = "Admin HTTP base URL. Defaults to loopback TCP; requires serve --admin-bind 127.0.0.1:8586 (or equivalent)."
+        )]
         admin_url: String,
     },
 }

--- a/docs/CONFIG-REFERENCE.md
+++ b/docs/CONFIG-REFERENCE.md
@@ -40,8 +40,11 @@ Config is resolved in this order (later overrides earlier):
 
 Operational note:
 
+- Recommended local operator path for `tail`/`detect`:
+  - run serve with admin on loopback TCP (`--admin-bind 127.0.0.1:8586`) or set `server.admin_socket = "127.0.0.1:8586"`.
+  - then use `tail` / `detect` defaults (no `--admin-url` required).
 - `tail` / `detect` CLI commands use HTTP URLs and default to `http://127.0.0.1:8586`.
-- If you keep `admin_socket` as a Unix path, start serve with `--admin-bind 127.0.0.1:8586` for those commands, or pass an explicit reachable admin URL.
+- If you keep `admin_socket` as a Unix path, `tail` / `detect` need an explicit reachable TCP admin bind.
 
 ## `[defaults]`
 
@@ -121,7 +124,7 @@ Observability runtime controls (applied by `penny-observe` at process startup):
 ```toml
 [server]
 bind = "127.0.0.1:8585"
-admin_socket = "~/.local/share/pennyprompt/admin.sock"
+admin_socket = "127.0.0.1:8586"
 database_path = "~/.local/share/pennyprompt/penny.db"
 mode = "guard"
 

--- a/docs/LIMITATIONS.md
+++ b/docs/LIMITATIONS.md
@@ -20,8 +20,8 @@ This list documents current constraints as of April 18, 2026.
 
 ## API/Control Plane Assumptions
 
-- `tail` and `detect` control commands assume admin API availability over HTTP (default `http://127.0.0.1:8586` in CLI commands).
-- If `serve` runs admin on a Unix socket path, use `--admin-bind 127.0.0.1:8586` (or equivalent TCP bind) for those commands.
+- `tail` and `detect` client commands are HTTP-only today (default `http://127.0.0.1:8586`).
+- Native unix-socket client connectivity for those commands is not implemented; expose admin over loopback TCP when using them.
 - If admin plane is unavailable, related commands fail as expected.
 
 ## Data and Reporting

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -62,6 +62,8 @@ Run `serve` in terminal A and keep it running:
 ./target/release/penny-cli serve --admin-bind 127.0.0.1:8586
 ```
 
+This is the recommended default topology for local operator workflows because `tail` and `detect` commands default to `http://127.0.0.1:8586`.
+
 If you want a fully local smoke test without provider keys:
 
 ```bash


### PR DESCRIPTION
## Summary
- define one clear local operator path: run admin on loopback TCP (127.0.0.1:8586) for tail/detect default connectivity
- update README, QUICKSTART, CONFIG-REFERENCE, and LIMITATIONS to remove ambiguous unix-socket-vs-http guidance
- clarify CLI help text for serve --admin-bind, tail --admin-url, and detect --admin-url
- validate runtime-facing examples against actual command help output

## Validation
- cargo fmt --all
- cargo check --workspace --locked
- cargo clippy -p penny-cli --all-targets --locked -- -D warnings
- cargo run -p penny-cli --locked -- tail --help
- cargo run -p penny-cli --locked -- detect status --help

## Exception
- Temporarily using label skip-issue-linkage because the PR linkage workflow in base main fails on its current regex implementation under pull_request_target.
- The fix for that workflow matcher is included in this branch.

Closes #152