### PR TITLE
docs(status): publish refreshed post-alpha audit snapshot

### DIFF
--- a/docs/status-2026-05-07.md
+++ b/docs/status-2026-05-07.md
@@ -1,0 +1,55 @@
+# PennyPrompt Post-Alpha Audit Snapshot — 2026-05-07
+
+This snapshot supersedes older status assessments that predate the post-alpha hardening sequence merged between April 26 and May 7, 2026.
+
+Repository baseline at capture time:
+- Branch: `main`
+- Commit: `5d491e0`
+
+## Evidence Index
+
+Recent merged PRs (selected, newest first):
+- [#165](https://github.com/manuelpenazuniga/PennyPrompt/pull/165) — tail/detect topology docs + CLI help alignment
+- [#164](https://github.com/manuelpenazuniga/PennyPrompt/pull/164) — PR issue linkage policy (template + workflow)
+- [#163](https://github.com/manuelpenazuniga/PennyPrompt/pull/163) — observe precedence (CLI explicit flags over env)
+- [#162](https://github.com/manuelpenazuniga/PennyPrompt/pull/162) — doctor robustness (timeouts, memory DSNs, datetime parsing)
+- [#161](https://github.com/manuelpenazuniga/PennyPrompt/pull/161) — deterministic and pre-import pricebook guardrail
+- [#160](https://github.com/manuelpenazuniga/PennyPrompt/pull/160) — serve shutdown outcome aggregation
+- [#159](https://github.com/manuelpenazuniga/PennyPrompt/pull/159) — admin bind contract hardening
+- [#158](https://github.com/manuelpenazuniga/PennyPrompt/pull/158) — release gate evidence + runner blocker capture
+
+Workflow evidence:
+- Main branch CI success after merge sequence: [CI run 25527055535](https://github.com/manuelpenazuniga/PennyPrompt/actions/runs/25527055535)
+- Linkage workflow failure mode observed and captured before fix landed: [PR Issue Linkage run 25526723008](https://github.com/manuelpenazuniga/PennyPrompt/actions/runs/25526723008)
+
+## Gap Reclassification (vs. prior audit)
+
+| Prior Gap | Current Status | Evidence |
+|---|---|---|
+| `pennyprompt serve` lifecycle and shutdown correctness | **Resolved** | [#135](https://github.com/manuelpenazuniga/PennyPrompt/pull/135), [#160](https://github.com/manuelpenazuniga/PennyPrompt/pull/160) |
+| Pricebook/default-model resolvability and transactional guardrail behavior | **Resolved** | [#137](https://github.com/manuelpenazuniga/PennyPrompt/pull/137), [#161](https://github.com/manuelpenazuniga/PennyPrompt/pull/161) |
+| Observe bootstrap present but precedence surprising (env beating explicit CLI) | **Resolved** | [#140](https://github.com/manuelpenazuniga/PennyPrompt/pull/140), [#163](https://github.com/manuelpenazuniga/PennyPrompt/pull/163) |
+| Doctor diagnostics fragility (timeouts, SQLite in-memory DSNs, datetime formats) | **Resolved** | [#162](https://github.com/manuelpenazuniga/PennyPrompt/pull/162) |
+| Admin topology ambiguity for `tail`/`detect` defaults | **Resolved** | [#165](https://github.com/manuelpenazuniga/PennyPrompt/pull/165) |
+| PR-to-issue trace discipline only convention-based | **Resolved** | [#164](https://github.com/manuelpenazuniga/PennyPrompt/pull/164) |
+| Alpha.2 release publication still pending despite gate/docs progress | **Pending** | [#158](https://github.com/manuelpenazuniga/PennyPrompt/pull/158), [Issue #144](https://github.com/manuelpenazuniga/PennyPrompt/issues/144) |
+
+## Open Risk Register
+
+| Risk | Severity | Why It Matters | Mapped Issue |
+|---|---|---|---|
+| Alpha.2 publication still not fully completed | High | Limits external credibility and reproducible onboarding claims | [#144](https://github.com/manuelpenazuniga/PennyPrompt/issues/144) |
+| Release gate/checklist guidance still needs tightening | Medium | Can reintroduce ambiguity in future cuts | [#154](https://github.com/manuelpenazuniga/PennyPrompt/issues/154) |
+| Deferred/rejected Gemini suggestions not yet formally recorded | Medium | Review debt context can be lost and re-litigated | [#155](https://github.com/manuelpenazuniga/PennyPrompt/issues/155) |
+| Epic closure and milestone framing still open | Low | Roadmap signal remains less crisp for external readers | [#142](https://github.com/manuelpenazuniga/PennyPrompt/issues/142) |
+
+## Next Actions (Ordered)
+
+1. Close [#154](https://github.com/manuelpenazuniga/PennyPrompt/issues/154) to finalize release-gate command/checksum guidance.
+2. Close [#155](https://github.com/manuelpenazuniga/PennyPrompt/issues/155) to document intentional non-fixes from review assistants.
+3. Execute and close [#144](https://github.com/manuelpenazuniga/PennyPrompt/issues/144) with final alpha.2 publication evidence.
+4. Reassess [#142](https://github.com/manuelpenazuniga/PennyPrompt/issues/142) scope once release publication is complete.
+
+## Summary
+
+As of 2026-05-07, the critical implementation gaps identified in the prior post-alpha audit are largely addressed through merged PRs. Remaining risk is concentrated in release completion and documentation closure, not core runtime correctness.


### PR DESCRIPTION
## Summary
- add a new dated status snapshot at docs/status-2026-05-07.md
- reclassify prior audit gaps as resolved/pending with explicit PR evidence links
- include a mapped risk register tied to open backlog issues
- define ordered next actions for release and documentation closure

## Validation
- content-only change; links and references validated against current GitHub state

Closes #153