### PR TITLE
docs(changelog): clarify v0.1.0-alpha.2 publication status note

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Changed
 - Observability startup precedence is now explicit: CLI flags (`--log-filter`, `--json-log`) override environment (`PENNY_LOG`/`RUST_LOG`, `PENNY_OBSERVE_JSON`), which still override built-in defaults. Backward-compatibility note: workflows relying on env vars to force logging behavior should stop passing conflicting CLI flags.
 
-## [v0.1.0-alpha.2] - 2026-04-30 (release publication pending under #144)
+## [v0.1.0-alpha.2] - 2026-04-30 (tag cut; GitHub Release artifacts pending — see #173)
 
 ### Added
 - `penny-cli serve` runtime lifecycle with proxy/admin startup and graceful shutdown flow (`#129`).


### PR DESCRIPTION
## Summary
- Rewrite the `v0.1.0-alpha.2` line in `CHANGELOG.md` so it no longer references a closed issue (#144) while keeping the truthful "artifacts not yet on github.com/releases" signal.
- Point readers to the live tracking issue (#173) for the actual GitHub Release publication work, so the next reader can see who is on the hook.

Before:
\`\`\`
## [v0.1.0-alpha.2] - 2026-04-30 (release publication pending under #144)
\`\`\`

After:
\`\`\`
## [v0.1.0-alpha.2] - 2026-04-30 (tag cut; GitHub Release artifacts pending — see #173)
\`\`\`

## Validation
- [x] `cargo fmt --all`
- [x] `cargo test --workspace --locked`
- [x] `cargo check --workspace --locked`
- [x] `cargo clippy --workspace --all-targets --locked -- -D warnings`

(Docs-only change; CI checks left from PR #171 baseline still applicable.)

## Issue Linkage (Required)
Closes #172

## Notes
- The alpha.1 caveat on line 28 (`internal milestone cut; public GitHub Release artifacts not yet reconciled`) is intentionally left alone — it is a separate question pending its own audit.
- The actual GitHub Release publication is tracked in #173.