### PR TITLE
ci(release): allow publish on partial build matrix success

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,11 @@ on:
     tags:
       - "v*"
   workflow_dispatch:
+    inputs:
+      version:
+        description: "Existing git tag to publish (e.g. v0.1.0-alpha.2). Must already exist as a tag on the repo."
+        required: true
+        type: string
 
 permissions:
   contents: write
@@ -29,6 +34,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.version || github.ref_name }}
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -43,9 +50,10 @@ jobs:
 
       - name: Package release artifact and checksum
         shell: bash
+        env:
+          VERSION: ${{ inputs.version || github.ref_name }}
         run: |
           set -euo pipefail
-          VERSION="${GITHUB_REF_NAME}"
           TARGET="${{ matrix.target }}"
           ASSET="penny-cli-${VERSION}-${TARGET}"
           mkdir -p dist
@@ -74,6 +82,11 @@ jobs:
     name: Publish release
     runs-on: ubuntu-24.04
     needs: build
+    # Run publish whenever the build matrix has terminated, even if one or
+    # more individual matrix entries failed or were cancelled (e.g. a stuck
+    # macos-13 runner). Workflow-level cancellation by a user still skips
+    # publish. The artifact-count guard below prevents empty publishes.
+    if: ${{ !cancelled() }}
     steps:
       - name: Download all release artifacts
         uses: actions/download-artifact@v4
@@ -81,6 +94,19 @@ jobs:
           pattern: release-*
           merge-multiple: true
           path: dist
+
+      - name: Require minimum artifact count
+        shell: bash
+        run: |
+          set -euo pipefail
+          ARTIFACT_COUNT=$(find dist -maxdepth 1 -name "*.tar.gz" | wc -l | tr -d ' ')
+          MIN_ARTIFACTS=3
+          if [ "${ARTIFACT_COUNT}" -lt "${MIN_ARTIFACTS}" ]; then
+            echo "::error::Refusing to publish: only ${ARTIFACT_COUNT} artifact(s) present, require at least ${MIN_ARTIFACTS}."
+            exit 1
+          fi
+          echo "Publishing release with ${ARTIFACT_COUNT} artifact(s):"
+          (cd dist && ls -1 *.tar.gz)
 
       - name: Build aggregated checksum file
         shell: bash
@@ -92,6 +118,7 @@ jobs:
       - name: Create GitHub release
         uses: softprops/action-gh-release@v2
         with:
+          tag_name: ${{ inputs.version || github.ref_name }}
           generate_release_notes: true
           prerelease: true
           files: |


### PR DESCRIPTION
## Summary
Three coordinated changes to `.github/workflows/release.yml` so the alpha publication path is resilient to single-target build failures (e.g. the recurring `macos-13` runner queueing on `x86_64-apple-darwin` that has been blocking `v0.1.0-alpha.2`).

1. **`if: ${{ !cancelled() }}` on the `publish` job.** A cancelled or failed individual matrix entry no longer prevents publishing the artifacts produced by the targets that did succeed. Workflow-level cancellation (user pressed Cancel run) still skips publish.
2. **Artifact-count guard inside `publish`.** Fails the publish step if fewer than 3 `.tar.gz` artifacts are present, so a near-empty matrix cannot accidentally publish an empty Release.
3. **`workflow_dispatch.inputs.version` parameter.** Threaded into `actions/checkout` (`ref:`), the packaging step (`VERSION` env), and `softprops/action-gh-release` (`tag_name:`). Lets us re-trigger the workflow against an existing tag without delete+retag:
   ```
   gh workflow run release.yml --ref main -f version=v0.1.0-alpha.2
   ```

Default behaviour for `push: tags: v*` is preserved — when triggered by a tag push, `inputs.version` is empty and every reference falls back to `github.ref_name`.

## Validation
- [x] `cargo fmt --all` — n/a (workflow-only change)
- [x] `cargo test --workspace --locked` — n/a (workflow-only change)
- [x] `cargo check --workspace --locked` — n/a (workflow-only change)
- [x] `cargo clippy --workspace --all-targets --locked -- -D warnings` — n/a (workflow-only change)
- [x] YAML parses cleanly (verified locally with Ruby psych, accounting for the YAML 1.1 `on:`→true quirk).
- [x] Local inspection of every interpolation site — all three fallback to `github.ref_name` when `inputs.version` is empty.

## Issue Linkage (Required)
Closes #175

## Notes
- This PR does **not** publish the alpha.2 release. It only unblocks the publication path.
- The fastest follow-up after merge is to use the 3 surviving artifacts that already exist in run [25174516142](https://github.com/manuelpenazuniga/PennyPrompt/actions/runs/25174516142) (`x86_64-unknown-linux-gnu`, `aarch64-unknown-linux-gnu`, `aarch64-apple-darwin`), download with `gh run download 25174516142`, and create the Release manually with `gh release create v0.1.0-alpha.2 dist/*`. This bypasses any further CI dependency on macos-13.
- If we prefer a fresh CI build, run `gh workflow run release.yml --ref main -f version=v0.1.0-alpha.2` after merge. With this PR in effect, the publish job will fire as soon as 3 of 4 matrix entries succeed.
- Tracker for the actual publication is #173.