### PR TITLE
docs(changelog): drop publication-pending caveat after v0.1.0-alpha.2 publish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Changed
 - Observability startup precedence is now explicit: CLI flags (`--log-filter`, `--json-log`) override environment (`PENNY_LOG`/`RUST_LOG`, `PENNY_OBSERVE_JSON`), which still override built-in defaults. Backward-compatibility note: workflows relying on env vars to force logging behavior should stop passing conflicting CLI flags.
 
-## [v0.1.0-alpha.2] - 2026-04-30 (tag cut; GitHub Release artifacts pending — see #173)
+## [v0.1.0-alpha.2] - 2026-04-30
 
 ### Added
 - `penny-cli serve` runtime lifecycle with proxy/admin startup and graceful shutdown flow (`#129`).


### PR DESCRIPTION
## Summary
The v0.1.0-alpha.2 GitHub Release was published on 2026-05-15 ([release page](https://github.com/manuelpenazuniga/PennyPrompt/releases/tag/v0.1.0-alpha.2)), and the tracker the previous caveat pointed to (#173) is closed. Drop the parenthetical from the CHANGELOG line so it no longer contradicts the actual release page.

Before:
\`\`\`
## [v0.1.0-alpha.2] - 2026-04-30 (tag cut; GitHub Release artifacts pending — see #173)
\`\`\`

After:
\`\`\`
## [v0.1.0-alpha.2] - 2026-04-30
\`\`\`

The Intel-Mac (`x86_64-apple-darwin`) exclusion from the initial publish is documented in the GitHub Release body itself, which is the right venue for that detail.

## Validation
- [x] `cargo fmt --all` — n/a (docs-only)
- [x] `cargo test --workspace --locked` — n/a (docs-only)
- [x] `cargo check --workspace --locked` — n/a (docs-only)
- [x] `cargo clippy --workspace --all-targets --locked -- -D warnings` — n/a (docs-only)
- [x] `gh release view v0.1.0-alpha.2` returns a valid pre-release.

## Issue Linkage (Required)
Closes #177

## Notes
- Net diff is one line.
- Sibling PR #176 already merged adds the workflow capability that makes future publishes resilient to single-target queue failures.