### PR TITLE
ci(release): cap build and publish jobs with timeout-minutes safety net

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,11 @@ jobs:
   build:
     name: Build ${{ matrix.target }}
     runs-on: ${{ matrix.os }}
+    # Cap each matrix entry so a runner that never gets allocated (e.g. a
+    # scarce macos-13 runner) cannot block the workflow indefinitely. With
+    # the partial-success publish gate added in #176, a timed-out entry
+    # no longer prevents publication of the surviving targets.
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
@@ -82,6 +87,7 @@ jobs:
     name: Publish release
     runs-on: ubuntu-24.04
     needs: build
+    timeout-minutes: 15
     # Run publish whenever the build matrix has terminated, even if one or
     # more individual matrix entries failed or were cancelled (e.g. a stuck
     # macos-13 runner). Workflow-level cancellation by a user still skips


### PR DESCRIPTION
## Summary
Add explicit `timeout-minutes` to each job in `.github/workflows/release.yml`:

- `build` matrix: **30 minutes** per entry.
- `publish`: **15 minutes**.

This is a defensive safety net that composes with the partial-success publish gate from #176. When a runner never gets allocated (the recurring `macos-13` / `x86_64-apple-darwin` queueing failure mode that blocked run [25174516142](https://github.com/manuelpenazuniga/PennyPrompt/actions/runs/25174516142) for 7 days), the corresponding matrix entry now fails at the 30-minute mark instead of sitting in the queue indefinitely. The matrix terminates, and `publish` fires against the surviving artifacts under the existing `if: !cancelled()` guard.

## Scope decision: keep `macos-13` in the matrix

Intentionally retaining `x86_64-apple-darwin` despite its queueing history. Two alternatives were considered and deferred:

- **Drop the target entirely**: pragmatic for an alpha given Intel-Mac market share, but defers documentation and INSTALL.md updates that are out of scope here.
- **Cross-compile from `macos-14`**: technically possible for pure-Rust crates, but complicated in this workspace because `libsqlite3-sys` does not bundle SQLite by default. Validating + switching the bundling feature is its own scope.

With the timeout + partial-success gate in place, neither of these is required to keep the publication path resilient.

## Validation
- [x] `cargo fmt --all` — n/a (workflow-only change)
- [x] `cargo test --workspace --locked` — n/a (workflow-only change)
- [x] `cargo check --workspace --locked` — n/a (workflow-only change)
- [x] `cargo clippy --workspace --all-targets --locked -- -D warnings` — n/a (workflow-only change)
- [x] YAML parses cleanly (verified locally with Ruby psych).
- [x] `doc['jobs']['build']['timeout-minutes'] == 30` and `doc['jobs']['publish']['timeout-minutes'] == 15`.

## Issue Linkage (Required)
Closes #178

## Notes
- 30 minutes is a generous upper bound for a single Rust release build with the existing `Swatinem/rust-cache@v2` step. Real wall-clock typical is under 5 minutes; the timeout is for the queue-stuck case, not for slow builds.
- If a build legitimately needs more than 30 minutes in the future (heavy LTO, very large workspace growth), bump the value — do not remove the timeout.