### PR TITLE
docs(release): record local x86_64-apple-darwin backfill provenance for v0.1.0-alpha.2

### DIFF
--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -92,3 +92,55 @@ Pinned version:
 ```bash
 curl -fsSL https://raw.githubusercontent.com/manuelpenazuniga/PennyPrompt/main/scripts/install.sh | PENNY_VERSION=v0.1.0-alpha.2 sh
 ```
+
+## Release Maturity Policy
+
+Alpha cuts are published as GitHub **Pre-release** by design. The `release.yml` workflow sets `prerelease: true` for the `softprops/action-gh-release` step, which means alpha tags do not receive the GitHub `Latest` badge and `GET /releases/latest` returns 404 until a non-alpha tag is published. This is intentional: the badge implies stability we do not yet claim. Promotion of a future stable cut to `Latest` will be handled either by removing the prerelease flag in `release.yml` for non-prerelease tags or by editing the published Release with `gh release edit <tag> --prerelease=false --latest`.
+
+## Operational Fallback: Local Build + Upload
+
+When a CI matrix entry cannot obtain a runner (for example a scarce `macos-13` Intel runner), the partial-success publish path landed in `#176` allows the rest of the targets to publish without blocking. The missing target can then be backfilled locally and uploaded to the same Release. Apple Silicon hosts can produce `x86_64-apple-darwin` natively because the Apple toolchain ships a multi-arch SDK; no `osxcross` or `cargo-zigbuild` is needed.
+
+The procedure used for `v0.1.0-alpha.2` (#181):
+
+```bash
+# 1. Sync main, then check out the exact tag commit (so Cargo.lock and source match).
+git switch main && git pull --ff-only origin main
+git checkout v0.1.0-alpha.2
+
+# 2. Add the target the first time.
+rustup target add x86_64-apple-darwin
+
+# 3. Build with --locked so the lockfile from the tag is enforced.
+cargo build --release -p penny-cli --target x86_64-apple-darwin --locked
+
+# 4. Package exactly as release.yml does.
+VERSION=v0.1.0-alpha.2
+TARGET=x86_64-apple-darwin
+ASSET="penny-cli-${VERSION}-${TARGET}"
+mkdir -p dist
+cp "target/${TARGET}/release/penny-cli" "dist/penny-cli"
+tar -C dist -czf "dist/${ASSET}.tar.gz" penny-cli
+( cd dist && shasum -a 256 "${ASSET}.tar.gz" > "${ASSET}.sha256" )
+rm -f dist/penny-cli
+
+# 5. Upload artifacts to the existing GitHub Release.
+gh release upload "${VERSION}" --repo manuelpenazuniga/PennyPrompt \
+  "dist/${ASSET}.tar.gz" "dist/${ASSET}.sha256"
+
+# 6. Regenerate aggregated CHECKSUMS.txt (alphabetical-by-filename).
+mkdir -p dist-checksums
+gh release download "${VERSION}" --repo manuelpenazuniga/PennyPrompt \
+  --pattern '*.sha256' --dir dist-checksums --clobber
+( cd dist-checksums && cat *.sha256 > CHECKSUMS.txt )
+gh release upload "${VERSION}" --repo manuelpenazuniga/PennyPrompt \
+  --clobber dist-checksums/CHECKSUMS.txt
+
+# 7. Verify end-to-end from a fresh temp dir.
+VD=$(mktemp -d) && cd "$VD"
+gh release download "${VERSION}" --repo manuelpenazuniga/PennyPrompt \
+  --pattern "penny-cli-${VERSION}-${TARGET}.*"
+shasum -a 256 -c "penny-cli-${VERSION}-${TARGET}.sha256"
+```
+
+Locally backfilled artifacts have a different host/SDK provenance from CI-built artifacts; this difference must be disclosed in the corresponding `docs/release-notes/<tag>.md` file under an `### Artifact provenance` section.

--- a/docs/RELEASE_GATE_v0.1.0-alpha.2.md
+++ b/docs/RELEASE_GATE_v0.1.0-alpha.2.md
@@ -2,13 +2,13 @@
 
 Objective gate for publishing `v0.1.0-alpha.2` after P0 onboarding/contract fixes.
 
-Execution note (updated 2026-05-07):
+Execution note (updated 2026-05-15):
 - Release run: https://github.com/manuelpenazuniga/PennyPrompt/actions/runs/25174516142
-- Current blocker remains `Build x86_64-apple-darwin`:
-  - latest rerun attempt: `run_attempt=3`
-  - job link: https://github.com/manuelpenazuniga/PennyPrompt/actions/runs/25174516142/job/74928756062
-  - queue metadata: `labels=[macos-13]`, `runner_id=null`, `status=queued`
-  - other three targets complete successfully in the same attempt.
+- Three of four matrix targets completed successfully in attempt-3.
+- `x86_64-apple-darwin` (`macos-13`) stayed queued indefinitely (`run_attempt=3`, `runner_id=null`) and was bypassed by the partial-success publish path landed in #176.
+- The Intel-Mac artifact was backfilled locally on Apple Silicon from the same tag commit (`41d662c`) and uploaded via `gh release upload` (tracked in #181).
+- Result: GitHub Release `v0.1.0-alpha.2` now carries 4 `.tar.gz` archives, 4 `.sha256` files, and an aggregated `CHECKSUMS.txt`.
+- The release remains marked as `prerelease: true` per `release.yml` policy (no GitHub `Latest` badge is expected on alpha cuts).
 
 ## 1. Scope Lock (P0 Closure)
 
@@ -79,11 +79,11 @@ Evidence:
 ## 5. CI and Release Workflow Gate
 
 - [x] Latest PR to `main` has CI check `Check, Test, Clippy, Fmt` green.
-- [ ] Release workflow (`.github/workflows/release.yml`) succeeded for all targets:
-  - [x] `x86_64-unknown-linux-gnu`
-  - [x] `aarch64-unknown-linux-gnu`
-  - [ ] `x86_64-apple-darwin` (pending runner allocation; job still queued)
-  - [x] `aarch64-apple-darwin`
+- [x] Release workflow (`.github/workflows/release.yml`) produced artifacts for all four targets (3 via CI, 1 via local Apple Silicon backfill, all uploaded to the same GitHub Release):
+  - [x] `x86_64-unknown-linux-gnu` (CI, `ubuntu-24.04`)
+  - [x] `aarch64-unknown-linux-gnu` (CI, `ubuntu-24.04-arm`)
+  - [x] `x86_64-apple-darwin` (local Apple Silicon backfill from tag commit `41d662c`; tracked in #181)
+  - [x] `aarch64-apple-darwin` (CI, `macos-14`)
 
 Evidence:
 - PR CI (latest merged PR #168):
@@ -94,13 +94,18 @@ Evidence:
   - attempt-3 job `aarch64-apple-darwin` (success): https://github.com/manuelpenazuniga/PennyPrompt/actions/runs/25174516142/job/74928756279
   - attempt-3 job `aarch64-unknown-linux-gnu` (success): https://github.com/manuelpenazuniga/PennyPrompt/actions/runs/25174516142/job/74928756259
   - attempt-3 job `x86_64-unknown-linux-gnu` (success): https://github.com/manuelpenazuniga/PennyPrompt/actions/runs/25174516142/job/74928756014
-  - attempt-3 job `x86_64-apple-darwin` (queued): https://github.com/manuelpenazuniga/PennyPrompt/actions/runs/25174516142/job/74928756062
+  - attempt-3 job `x86_64-apple-darwin` (queued/bypassed via #176): https://github.com/manuelpenazuniga/PennyPrompt/actions/runs/25174516142/job/74928756062
+- Local backfill (Intel-Mac):
+  - Built from tag commit `41d662c` with `cargo build --release -p penny-cli --target x86_64-apple-darwin --locked`.
+  - `file penny-cli` reports `Mach-O 64-bit executable x86_64`.
+  - Published SHA-256: `8a02e74fbd7d89730dbb145769d3b4fb9da4650ed8d71c58e728e14fa06d6c6e`.
+  - Provenance is intentionally distinct from the CI-built artifacts (different toolchain host, different SDK timestamps); checksum integrity remains verifiable end-to-end.
 
 ## 6. Artifact Verification Gate
 
-- [ ] Release has 4 `.tar.gz` artifacts and 4 `.sha256` files.
-- [ ] `CHECKSUMS.txt` present and complete.
-- [ ] At least one target checksum verified locally with a concrete command.
+- [x] Release has 4 `.tar.gz` artifacts and 4 `.sha256` files.
+- [x] `CHECKSUMS.txt` present and complete (4 entries, alphabetical-by-filename, regenerated after the local backfill).
+- [x] At least one target checksum verified locally with a concrete command (Intel-Mac artifact verified end-to-end after upload).
 
 Reference checksum commands (macOS/Linux):
 
@@ -117,8 +122,7 @@ shasum -a 256 -c penny-cli-v0.1.0-alpha.2-x86_64-unknown-linux-gnu.sha256
 ```
 
 Status:
-- Blocked until release workflow fully completes and publishes release assets.
-- `gh release view v0.1.0-alpha.2` currently returns `release not found` (2026-05-07), which is expected while publish job remains gated by the queued macOS x86 target.
+- Cleared on 2026-05-15. `gh release view v0.1.0-alpha.2` returns the published Release with all 4 archives, 4 `.sha256` files, and aggregated `CHECKSUMS.txt`.
 
 ## 7. Release Notes Gate
 
@@ -134,9 +138,9 @@ Evidence:
 
 ## 8. Publish Decision
 
-- [ ] All required boxes above are checked.
-- [x] Remaining non-blocking items are tracked in open issues.
+- [x] All required boxes above are checked.
+- [x] Remaining non-blocking items are tracked in open issues (alpha.3 backlog framing in `docs/status-2026-05-14.md`).
 - [x] Tag pushed as `v0.1.0-alpha.2`.
 
 Status:
-- Gate execution is in progress. Final completion still depends on `x86_64-apple-darwin` obtaining a `macos-13` runner and successful publish of release assets/checksums.
+- Gate cleared on 2026-05-15. Release is published with `prerelease: true` (intentional alpha policy) and contains all four target archives. Provenance for the Intel-Mac artifact is documented in #181 and disclosed in `docs/release-notes/v0.1.0-alpha.2.md`.

--- a/docs/release-notes/v0.1.0-alpha.2.md
+++ b/docs/release-notes/v0.1.0-alpha.2.md
@@ -1,6 +1,6 @@
 # PennyPrompt v0.1.0-alpha.2
 
-Publication status: release notes finalized; GitHub Release publication is tracked in #144.
+Publication status: GitHub Release published on 2026-05-15 (`prerelease: true`, intentional alpha policy).
 
 ## Summary
 
@@ -27,3 +27,8 @@ Current alpha limitations are documented in [docs/LIMITATIONS.md](../LIMITATIONS
 
 - 4 target archives (`.tar.gz`) for Linux/macOS on `x86_64` + `arm64`
 - Per-target SHA-256 files and aggregated `CHECKSUMS.txt`
+
+### Artifact provenance
+
+- `x86_64-unknown-linux-gnu`, `aarch64-unknown-linux-gnu`, `aarch64-apple-darwin`: built by GitHub Actions runners (`ubuntu-24.04`, `ubuntu-24.04-arm`, `macos-14`) from tag commit `41d662c`.
+- `x86_64-apple-darwin`: built locally on Apple Silicon from the same tag commit using the system Apple toolchain (no CI runner allocated for `macos-13` within the workflow timeout window). Published SHA-256: `8a02e74fbd7d89730dbb145769d3b4fb9da4650ed8d71c58e728e14fa06d6c6e`. Tracked in #181.


### PR DESCRIPTION
Closes #181.

## What changed

Documents the post-publication state of the `v0.1.0-alpha.2` GitHub Release after the missing `x86_64-apple-darwin` artifact was backfilled locally on Apple Silicon and uploaded alongside the three CI-built archives.

- `docs/RELEASE_GATE_v0.1.0-alpha.2.md`: closes out sections 5/6/8 with 4-of-4 target completion, links the queued/bypassed CI job to `#176`, and the local backfill to `#181`. Top-of-file execution note refreshed for 2026-05-15.
- `docs/release-notes/v0.1.0-alpha.2.md`: drops the `#144` tracker reference (publication is done), adds an explicit **Artifact provenance** section disclosing that 3 archives are CI-built and 1 is locally built on Apple Silicon, with the published SHA-256 for the Intel-Mac artifact.
- `docs/RELEASE.md`: appends two new sections.
  - **Release Maturity Policy** documents that alpha cuts are intentionally `prerelease: true` and points to the future stable promotion path.
  - **Operational Fallback: Local Build + Upload** captures the exact backfill recipe used for alpha.2 (`rustup target add` -> `cargo build --locked` -> `tar` -> `shasum` -> `gh release upload` -> regenerate `CHECKSUMS.txt`).

## Provenance facts

- 3 CI-built artifacts: `x86_64-unknown-linux-gnu`, `aarch64-unknown-linux-gnu`, `aarch64-apple-darwin` from tag commit `41d662c`.
- 1 locally built artifact: `x86_64-apple-darwin` from the same tag commit on Apple Silicon (Apple toolchain, native multi-arch SDK, no `osxcross`/`cargo-zigbuild`).
- Published SHA-256 for the Intel-Mac artifact: `8a02e74fbd7d89730dbb145769d3b4fb9da4650ed8d71c58e728e14fa06d6c6e`.
- `CHECKSUMS.txt` regenerated alphabetically-by-filename, matches the 4 individual `.sha256` files.

## Validation

- `gh release view v0.1.0-alpha.2 --repo manuelpenazuniga/PennyPrompt` returns 9 assets (4 `.tar.gz`, 4 `.sha256`, 1 `CHECKSUMS.txt`), `prerelease: true`.
- End-to-end smoke test passed from a clean temp dir:
  - `gh release download` -> `shasum -a 256 -c penny-cli-v0.1.0-alpha.2-x86_64-apple-darwin.sha256` -> `OK`.
  - `CHECKSUMS.txt` line for `x86_64-apple-darwin` matches the standalone `.sha256` content.
- Docs-only PR; no code changes; no CI-impacting modifications beyond touched markdown files.
