### PR TITLE
security: add cargo audit gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,15 @@ jobs:
       - name: Cache cargo and target
         uses: Swatinem/rust-cache@v2
 
+      - name: Install cargo-audit
+        run: cargo install cargo-audit --locked
+
+      - name: Cargo audit
+        run: |
+          # rsa is pulled into Cargo.lock by sqlx's optional MySQL support,
+          # but it is not present in the active normal dependency graph.
+          cargo audit --ignore RUSTSEC-2023-0071
+
       - name: Cargo check
         run: cargo check --workspace --locked
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1250,7 +1250,7 @@ dependencies = [
  "num-integer",
  "num-iter",
  "num-traits",
- "rand 0.8.5",
+ "rand 0.8.6",
  "smallvec",
  "zeroize",
 ]
@@ -1684,9 +1684,9 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
@@ -1914,9 +1914,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.11"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20a6af516fea4b20eccceaf166e8aa666ac996208e8a644ce3ef5aa783bc7cd4"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -2242,7 +2242,7 @@ dependencies = [
  "memchr",
  "once_cell",
  "percent-encoding",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rsa",
  "serde",
  "sha1",
@@ -2282,7 +2282,7 @@ dependencies = [
  "md-5",
  "memchr",
  "once_cell",
- "rand 0.8.5",
+ "rand 0.8.6",
  "serde",
  "serde_json",
  "sha2",

--- a/crates/penny-admin/Cargo.toml
+++ b/crates/penny-admin/Cargo.toml
@@ -15,7 +15,7 @@ penny-store = { path = "../penny-store" }
 penny-types = { path = "../penny-types" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-sqlx = { version = "0.8", features = ["runtime-tokio-rustls", "sqlite"] }
+sqlx = { version = "0.8", default-features = false, features = ["runtime-tokio-rustls", "sqlite"] }
 tokio = { version = "1", features = ["net", "time"] }
 tracing = "0.1"
 thiserror = "2"

--- a/crates/penny-budget/Cargo.toml
+++ b/crates/penny-budget/Cargo.toml
@@ -10,7 +10,7 @@ penny-ledger = { path = "../penny-ledger" }
 penny-store = { path = "../penny-store" }
 penny-types = { path = "../penny-types" }
 serde_json = "1"
-sqlx = { version = "0.8", features = ["runtime-tokio-rustls", "sqlite"] }
+sqlx = { version = "0.8", default-features = false, features = ["runtime-tokio-rustls", "sqlite"] }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }

--- a/crates/penny-cli/Cargo.toml
+++ b/crates/penny-cli/Cargo.toml
@@ -21,7 +21,7 @@ penny-proxy = { path = "../penny-proxy" }
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls", "stream"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-sqlx = { version = "0.8", features = ["runtime-tokio-rustls", "sqlite"] }
+sqlx = { version = "0.8", default-features = false, features = ["runtime-tokio-rustls", "sqlite"] }
 tempfile = "3"
 thiserror = "1"
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "net", "signal", "time"] }

--- a/crates/penny-cost/Cargo.toml
+++ b/crates/penny-cost/Cargo.toml
@@ -10,7 +10,7 @@ penny-store = { path = "../penny-store" }
 penny-types = { path = "../penny-types" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-sqlx = { version = "0.8", features = ["chrono", "runtime-tokio-rustls", "sqlite"] }
+sqlx = { version = "0.8", default-features = false, features = ["chrono", "runtime-tokio-rustls", "sqlite"] }
 thiserror = "1"
 tiktoken-rs = "0.6"
 toml = "0.8"

--- a/crates/penny-ledger/Cargo.toml
+++ b/crates/penny-ledger/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 [dependencies]
 penny-store = { path = "../penny-store" }
 penny-types = { path = "../penny-types" }
-sqlx = { version = "0.8", features = ["runtime-tokio-rustls", "sqlite"] }
+sqlx = { version = "0.8", default-features = false, features = ["runtime-tokio-rustls", "sqlite"] }
 thiserror = "1"
 
 [dev-dependencies]

--- a/crates/penny-proxy/Cargo.toml
+++ b/crates/penny-proxy/Cargo.toml
@@ -19,7 +19,7 @@ penny-types = { path = "../penny-types" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 regex = "1"
-sqlx = { version = "0.8", features = ["runtime-tokio-rustls", "sqlite"] }
+sqlx = { version = "0.8", default-features = false, features = ["runtime-tokio-rustls", "sqlite"] }
 thiserror = "1"
 tokio = { version = "1", features = ["net", "rt"] }
 tokio-stream = "0.1"

--- a/crates/penny-store/Cargo.toml
+++ b/crates/penny-store/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 chrono = { version = "0.4", features = ["serde"] }
 penny-types = { path = "../penny-types" }
 serde_json = "1"
-sqlx = { version = "0.8", features = ["chrono", "json", "migrate", "runtime-tokio-rustls", "sqlite", "uuid"] }
+sqlx = { version = "0.8", default-features = false, features = ["chrono", "json", "migrate", "runtime-tokio-rustls", "sqlite", "uuid"] }
 thiserror = "1"
 uuid = { version = "1", features = ["serde", "v7"] }
 

--- a/crates/penny-store/src/lib.rs
+++ b/crates/penny-store/src/lib.rs
@@ -1,6 +1,6 @@
 //! Persistence layer for PennyPrompt.
 
-use std::{path::Path, str::FromStr};
+use std::{borrow::Cow, path::Path, str::FromStr, sync::OnceLock};
 
 use chrono::{DateTime, NaiveDateTime, Utc};
 use penny_types::{
@@ -9,14 +9,77 @@ use penny_types::{
 };
 use serde_json::Value;
 use sqlx::{
-    migrate::Migrator,
+    migrate::{Migration, MigrationType, Migrator},
     sqlite::{SqliteConnectOptions, SqlitePoolOptions},
     QueryBuilder, Row, Sqlite, SqlitePool,
 };
 use thiserror::Error;
 use uuid::Uuid;
 
-static MIGRATOR: Migrator = sqlx::migrate!("../../migrations");
+fn embedded_migrator() -> &'static Migrator {
+    static MIGRATOR: OnceLock<Migrator> = OnceLock::new();
+
+    MIGRATOR.get_or_init(|| Migrator {
+        migrations: Cow::Owned(vec![
+            embedded_migration(
+                1,
+                "projects_sessions",
+                include_str!("../../../migrations/0001_projects_sessions.sql"),
+            ),
+            embedded_migration(
+                2,
+                "providers_models",
+                include_str!("../../../migrations/0002_providers_models.sql"),
+            ),
+            embedded_migration(
+                3,
+                "pricebook",
+                include_str!("../../../migrations/0003_pricebook.sql"),
+            ),
+            embedded_migration(
+                4,
+                "requests_usage",
+                include_str!("../../../migrations/0004_requests_usage.sql"),
+            ),
+            embedded_migration(
+                5,
+                "budgets",
+                include_str!("../../../migrations/0005_budgets.sql"),
+            ),
+            embedded_migration(
+                6,
+                "cost_ledger",
+                include_str!("../../../migrations/0006_cost_ledger.sql"),
+            ),
+            embedded_migration(
+                7,
+                "events",
+                include_str!("../../../migrations/0007_events.sql"),
+            ),
+            embedded_migration(
+                8,
+                "money_micros",
+                include_str!("../../../migrations/0008_money_micros.sql"),
+            ),
+            embedded_migration(
+                9,
+                "pricebook_micros",
+                include_str!("../../../migrations/0009_pricebook_micros.sql"),
+            ),
+        ]),
+        ..Migrator::DEFAULT
+    })
+}
+
+fn embedded_migration(version: i64, description: &'static str, sql: &'static str) -> Migration {
+    Migration::new(
+        version,
+        Cow::Borrowed(description),
+        MigrationType::Simple,
+        Cow::Borrowed(sql),
+        false,
+    )
+}
 
 #[derive(Debug, Error)]
 pub enum StoreError {
@@ -48,7 +111,7 @@ impl SqliteStore {
         sqlx::query("PRAGMA journal_mode=WAL;")
             .execute(&pool)
             .await?;
-        MIGRATOR.run(&pool).await?;
+        embedded_migrator().run(&pool).await?;
 
         Ok(Self { pool })
     }
@@ -969,6 +1032,41 @@ mod tests {
             .expect("upsert project");
         let session_id = store.create(&project_id).await.expect("create session");
         (project_id, session_id)
+    }
+
+    #[test]
+    fn embedded_migrations_match_migration_files() {
+        let migration_dir = Path::new(env!("CARGO_MANIFEST_DIR")).join("../../migrations");
+        let mut expected = std::fs::read_dir(migration_dir)
+            .expect("read migrations directory")
+            .map(|entry| {
+                let entry = entry.expect("read migration entry");
+                let file_name = entry
+                    .file_name()
+                    .into_string()
+                    .expect("migration filename is valid utf-8");
+                let stem = file_name
+                    .strip_suffix(".sql")
+                    .expect("migration file has .sql suffix");
+                let (version, description) = stem
+                    .split_once('_')
+                    .expect("migration filename has version and description");
+                (
+                    version
+                        .parse::<i64>()
+                        .expect("migration version is numeric"),
+                    description.to_string(),
+                )
+            })
+            .collect::<Vec<_>>();
+        expected.sort();
+
+        let actual = embedded_migrator()
+            .iter()
+            .map(|migration| (migration.version, migration.description.to_string()))
+            .collect::<Vec<_>>();
+
+        assert_eq!(actual, expected);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
- update rustls-webpki to 0.103.13 and rand 0.8.6 in Cargo.lock
- disable sqlx default features across local crates so the active graph stays sqlite/rustls-only
- replace sqlx::migrate! with embedded migrations without sqlx macros, plus a sync test for migration files
- add cargo-audit to CI with a documented ignore for RUSTSEC-2023-0071 because rsa is only present through sqlx optional MySQL lockfile metadata and not in the active normal graph

Closes #189

## Validation
- cargo fmt --all -- --check
- cargo audit --ignore RUSTSEC-2023-0071
- cargo tree -e normal --workspace --locked | rg -n "rsa|sqlx-postgres|sqlx-mysql|sqlx-macros|rand v0\.8\.5|rustls-webpki"
- cargo check --workspace --locked
- cargo clippy --workspace --all-targets --locked -- -D warnings
- HOME=/private/tmp/pennyprompt-audit-home RUSTUP_HOME=/Users/mpz/.rustup CARGO_HOME=/Users/mpz/.cargo cargo test --workspace --locked
