### PR TITLE
docs: clarify admin security contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -371,9 +371,10 @@ pricebook_entries: versioned, with effective_from/effective_until
 | Plane | Bind | Purpose |
 |-------|------|---------|
 | Proxy | `127.0.0.1:8585` | Agent traffic. OpenAI-compatible API. |
-| Admin | Unix socket (default) or `:8586` with token | Reports, budgets, health, events. |
+| Admin | Unix socket (default) or loopback TCP (`127.0.0.1:8586`) | Local operator APIs: reports, budgets, health, events. |
 
 Separated by design. Exposing `:8585` to the network never exposes admin endpoints.
+For the current alpha, admin TCP is a local-control-plane convenience only. Do not expose it outside loopback; bearer/admin-token auth is not implemented yet.
 
 ## Compatibility
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -61,6 +61,11 @@ Key properties:
   - estimate endpoint
   - detect status/resume
   - events SSE stream
+- Current alpha security contract:
+  - local control plane only
+  - bind admin to a Unix socket or loopback TCP
+  - bearer/admin-token auth is not implemented yet
+  - proxy routes do not expose admin endpoints
 
 ## CLI Plane
 

--- a/docs/CONFIG-REFERENCE.md
+++ b/docs/CONFIG-REFERENCE.md
@@ -32,9 +32,11 @@ Config is resolved in this order (later overrides earlier):
 ## `[server]`
 
 - `bind` (`string`): proxy bind address (example `127.0.0.1:8585`)
-- `admin_socket` (`string`): admin bind target
+- `admin_socket` (`string`): admin bind target for the local admin control plane
   - if value is `host:port` (for example `localhost:8586` or `127.0.0.1:8586`), admin binds TCP
+  - TCP admin binds are alpha local-only; use loopback addresses and do not expose them to LAN/public networks
   - otherwise admin binds a Unix socket path
+  - bearer/admin-token auth is not implemented in the current alpha
 - `database_path` (`string`): SQLite database path
 - `mode` (`observe|guard`)
 
@@ -44,7 +46,7 @@ Operational note:
   - run serve with admin on loopback TCP (`--admin-bind 127.0.0.1:8586`) or set `server.admin_socket = "127.0.0.1:8586"`.
   - then use `tail` / `detect` defaults (no `--admin-url` required).
 - `tail` / `detect` CLI commands use HTTP URLs and default to `http://127.0.0.1:8586`.
-- If you keep `admin_socket` as a Unix path, `tail` / `detect` need an explicit reachable TCP admin bind.
+- If you keep `admin_socket` as a Unix path, `tail` / `detect` need a loopback TCP admin bind because native Unix-socket clients are not implemented for those commands yet.
 
 ## `[defaults]`
 

--- a/docs/LIMITATIONS.md
+++ b/docs/LIMITATIONS.md
@@ -20,6 +20,8 @@ This list documents current constraints as of April 18, 2026.
 
 ## API/Control Plane Assumptions
 
+- Admin APIs have no bearer token or admin-token authentication in the current alpha; treat the admin plane as local-only.
+- Use a Unix socket or loopback TCP for admin. Do not expose admin binds to LAN or public networks.
 - `tail` and `detect` client commands are HTTP-only today (default `http://127.0.0.1:8586`).
 - Native unix-socket client connectivity for those commands is not implemented; expose admin over loopback TCP when using them.
 - If admin plane is unavailable, related commands fail as expected.


### PR DESCRIPTION
## Summary
- remove the README claim that admin TCP has token auth
- document current alpha admin as local-only: Unix socket or loopback TCP
- make CONFIG/LIMITATIONS/ARCHITECTURE explicit that bearer/admin-token auth is not implemented yet

Closes #190

## Validation
- git diff --check -- README.md docs/ARCHITECTURE.md docs/CONFIG-REFERENCE.md docs/LIMITATIONS.md
- rg -n "with token|admin-token|bearer|Bearer|Authorization|admin_token|auth|README.md|README" README.md docs/CONFIG-REFERENCE.md docs/LIMITATIONS.md docs/ARCHITECTURE.md docs/QUICKSTART.md docs/INSTALL.md docs/RELEASE.md docs/ALPHA-MANUAL-CHECKLIST.md -S
