### PR TITLE
feat: dispatch token estimates by model

### DIFF
--- a/crates/penny-admin/src/lib.rs
+++ b/crates/penny-admin/src/lib.rs
@@ -22,7 +22,7 @@ use axum::{
 };
 use chrono::{DateTime, Utc};
 use penny_config::LoopAction;
-use penny_cost::{estimate_tokens, PricingEngine};
+use penny_cost::{estimate_tokens_for_model_id, PricingEngine};
 use penny_detect::{DetectEngine, DetectStatus};
 use penny_store::{BudgetRepo, EventRepo, NewEvent, SqliteStore, StoreError};
 use penny_types::{
@@ -807,7 +807,7 @@ async fn post_estimate(
                     "provide context_tokens or messages".to_string(),
                 );
             };
-            estimate_tokens(messages).input_tokens
+            estimate_tokens_for_model_id(model, messages).input_tokens
         }
     };
 

--- a/crates/penny-cli/src/main.rs
+++ b/crates/penny-cli/src/main.rs
@@ -17,7 +17,7 @@ use penny_config::{
     load_config, resolve_user_config_path, AppConfig, ConfigError, LoadOptions, ProviderConfig,
     PRESET_EXPLORE, PRESET_INDIE, PRESET_TEAM,
 };
-use penny_cost::{estimate_tokens, import_pricebook_files, PricingEngine};
+use penny_cost::{estimate_tokens_for_model_id, import_pricebook_files, PricingEngine};
 use penny_detect::DetectEngine;
 use penny_observe::{ObserveConfig, ObserveRuntimeOverrides};
 use penny_providers::{
@@ -1191,6 +1191,7 @@ async fn run_report_top(store: &SqliteStore, limit: u32) -> Result<(), CliError>
 
 async fn run_estimate(store: &SqliteStore, command: EstimateCommand) -> Result<(), CliError> {
     let context = estimate_context(
+        command.model.as_str(),
         command.context_tokens,
         &command.context_files,
         command.max_files,
@@ -2578,6 +2579,7 @@ async fn autodetect_project_id(store: &SqliteStore) -> Result<Option<String>, Cl
 }
 
 fn estimate_context(
+    model_id: &str,
     context_tokens: Option<u64>,
     context_files: &[String],
     max_files: usize,
@@ -2609,7 +2611,7 @@ fn estimate_context(
         content.push('\n');
     }
 
-    let estimate = estimate_tokens(&Value::String(content));
+    let estimate = estimate_tokens_for_model_id(model_id, &Value::String(content));
     Ok(ContextEstimate {
         tokens: estimate.input_tokens,
         file_count: files.len(),
@@ -3487,21 +3489,28 @@ mod tests {
         fs::write(root.join("src/nested/mod.rs"), "pub fn b() {}").expect("write");
 
         let pattern = format!("{}/src/**/*.rs", root.display());
-        let estimate = estimate_context(None, &[pattern], 100).expect("estimate context");
+        let estimate =
+            estimate_context("gpt-4.1", None, &[pattern], 100).expect("estimate context");
         assert_eq!(estimate.file_count, 2);
         assert!(estimate.tokens > 0);
     }
 
     #[test]
     fn estimate_context_requires_tokens_or_files() {
-        let error = estimate_context(None, &[], 100).expect_err("missing context must fail");
+        let error =
+            estimate_context("gpt-4.1", None, &[], 100).expect_err("missing context must fail");
         assert!(matches!(error, CliError::MissingEstimateContext));
     }
 
     #[test]
     fn estimate_context_fails_when_no_files_match() {
-        let error = estimate_context(None, &[String::from("/tmp/does-not-exist/**/*.rs")], 100)
-            .expect_err("expected no matches");
+        let error = estimate_context(
+            "gpt-4.1",
+            None,
+            &[String::from("/tmp/does-not-exist/**/*.rs")],
+            100,
+        )
+        .expect_err("expected no matches");
         assert!(matches!(error, CliError::NoContextFilesMatched));
     }
 

--- a/crates/penny-cost/src/lib.rs
+++ b/crates/penny-cost/src/lib.rs
@@ -8,7 +8,7 @@ use penny_types::{Confidence, CostRange, Money, MoneyError, TaskType, UsageSourc
 use serde::Deserialize;
 use serde_json::Value;
 use thiserror::Error;
-use tiktoken_rs::cl100k_base;
+use tiktoken_rs::{cl100k_base, o200k_base};
 
 #[derive(Debug, Error)]
 pub enum CostError {
@@ -35,6 +35,14 @@ pub struct TokenEstimate {
     pub input_tokens: u64,
     pub output_tokens: u64,
     pub source: UsageSource,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TokenizerKind {
+    Cl100kBase,
+    O200kBase,
+    AnthropicV2,
+    Heuristic,
 }
 
 #[derive(Debug, Clone)]
@@ -80,6 +88,10 @@ impl<'a, R: PricebookRepo> PricingEngine<'a, R> {
     /// Output tokens use heuristic `min(input * 0.3, 4096)`.
     pub fn estimate_tokens(&self, messages: &Value) -> TokenEstimate {
         estimate_tokens(messages)
+    }
+
+    pub fn estimate_tokens_for_model(&self, model_id: &str, messages: &Value) -> TokenEstimate {
+        estimate_tokens_for_model_id(model_id, messages)
     }
 
     pub async fn snapshot(&self, model_id: &str) -> Result<Value, CostError> {
@@ -131,20 +143,54 @@ impl<'a, R: PricebookRepo> PricingEngine<'a, R> {
 }
 
 pub fn estimate_tokens(messages: &Value) -> TokenEstimate {
+    estimate_tokens_for_model(messages, &TokenizerKind::Cl100kBase)
+}
+
+pub fn estimate_tokens_for_model_id(model_id: &str, messages: &Value) -> TokenEstimate {
+    let tokenizer = tokenizer_kind_for_model(model_id);
+    estimate_tokens_for_model(messages, &tokenizer)
+}
+
+pub fn estimate_tokens_for_model(messages: &Value, tokenizer: &TokenizerKind) -> TokenEstimate {
     let content_text = extract_message_text(messages);
     if content_text.trim().is_empty() {
-        let input = heuristic_chars_to_tokens(messages.to_string().chars().count());
-        return TokenEstimate {
-            input_tokens: input,
-            output_tokens: estimate_output_tokens(input),
-            source: UsageSource::Heuristic,
-        };
+        return estimate_from_chars(messages.to_string().chars().count());
     }
 
-    match cl100k_base() {
+    match tokenizer {
+        TokenizerKind::Cl100kBase => estimate_with_tiktoken(&content_text, cl100k_base()),
+        TokenizerKind::O200kBase => estimate_with_tiktoken(&content_text, o200k_base()),
+        TokenizerKind::AnthropicV2 => estimate_anthropic_v2_tokens(&content_text),
+        TokenizerKind::Heuristic => estimate_from_chars(content_text.chars().count()),
+    }
+}
+
+pub fn tokenizer_kind_for_model(model_id: &str) -> TokenizerKind {
+    let normalized = model_id.trim().to_ascii_lowercase();
+    if normalized.starts_with("claude-") {
+        return TokenizerKind::AnthropicV2;
+    }
+    if normalized.starts_with("gpt-4o") || normalized.starts_with("chatgpt-4o") {
+        return TokenizerKind::O200kBase;
+    }
+    if normalized == "gpt-4"
+        || normalized.starts_with("gpt-4.1")
+        || normalized.starts_with("gpt-4-")
+    {
+        return TokenizerKind::Cl100kBase;
+    }
+
+    TokenizerKind::Heuristic
+}
+
+fn estimate_with_tiktoken<E>(
+    content_text: &str,
+    encoding: Result<tiktoken_rs::CoreBPE, E>,
+) -> TokenEstimate {
+    match encoding {
         Ok(encoding) => {
             let input = encoding
-                .encode_with_special_tokens(&content_text)
+                .encode_with_special_tokens(content_text)
                 .len()
                 .try_into()
                 .unwrap_or(u64::MAX);
@@ -162,6 +208,31 @@ pub fn estimate_tokens(messages: &Value) -> TokenEstimate {
                 source: UsageSource::Heuristic,
             }
         }
+    }
+}
+
+fn estimate_anthropic_v2_tokens(content_text: &str) -> TokenEstimate {
+    const ANTHROPIC_V2_CL100K_MULTIPLIER: f64 = 1.35;
+
+    let base = estimate_with_tiktoken(content_text, cl100k_base());
+    if base.source == UsageSource::Heuristic {
+        return base;
+    }
+
+    let input = ((base.input_tokens as f64) * ANTHROPIC_V2_CL100K_MULTIPLIER).ceil() as u64;
+    TokenEstimate {
+        input_tokens: input,
+        output_tokens: estimate_output_tokens(input),
+        source: UsageSource::Estimated,
+    }
+}
+
+fn estimate_from_chars(chars: usize) -> TokenEstimate {
+    let input = heuristic_chars_to_tokens(chars);
+    TokenEstimate {
+        input_tokens: input,
+        output_tokens: estimate_output_tokens(input),
+        source: UsageSource::Heuristic,
     }
 }
 
@@ -460,6 +531,176 @@ mod tests {
         ]);
         let result = estimate_tokens(&payload);
         assert!(result.input_tokens > 0);
+        assert_eq!(result.source, UsageSource::Heuristic);
+    }
+
+    fn short_english_messages() -> Value {
+        serde_json::json!([
+            { "role": "user", "content": "Hello from PennyPrompt. Estimate this request." }
+        ])
+    }
+
+    fn long_code_messages() -> Value {
+        serde_json::json!([{
+            "role": "user",
+            "content": "fn main() {\n    let mut total = 0;\n    for index in 0..128 {\n        total += index * 2;\n        println!(\"{index}: {total}\");\n    }\n}\n".repeat(8)
+        }])
+    }
+
+    fn assert_token_estimate(
+        payload: &Value,
+        tokenizer: TokenizerKind,
+        input_tokens: u64,
+        output_tokens: u64,
+        source: UsageSource,
+    ) {
+        let estimate = estimate_tokens_for_model(payload, &tokenizer);
+        assert_eq!(
+            estimate,
+            TokenEstimate {
+                input_tokens,
+                output_tokens,
+                source
+            },
+            "unexpected estimate for {tokenizer:?}"
+        );
+    }
+
+    #[test]
+    fn tokenizer_kinds_cover_empty_short_and_long_fixtures() {
+        let empty = serde_json::json!([]);
+        for tokenizer in [
+            TokenizerKind::Cl100kBase,
+            TokenizerKind::O200kBase,
+            TokenizerKind::AnthropicV2,
+            TokenizerKind::Heuristic,
+        ] {
+            assert_token_estimate(&empty, tokenizer, 1, 0, UsageSource::Heuristic);
+        }
+
+        let short = short_english_messages();
+        assert_token_estimate(
+            &short,
+            TokenizerKind::Cl100kBase,
+            9,
+            3,
+            UsageSource::Estimated,
+        );
+        assert_token_estimate(
+            &short,
+            TokenizerKind::O200kBase,
+            9,
+            3,
+            UsageSource::Estimated,
+        );
+        assert_token_estimate(
+            &short,
+            TokenizerKind::AnthropicV2,
+            13,
+            4,
+            UsageSource::Estimated,
+        );
+        assert_token_estimate(
+            &short,
+            TokenizerKind::Heuristic,
+            12,
+            4,
+            UsageSource::Heuristic,
+        );
+
+        let long = long_code_messages();
+        assert_token_estimate(
+            &long,
+            TokenizerKind::Cl100kBase,
+            320,
+            96,
+            UsageSource::Estimated,
+        );
+        assert_token_estimate(
+            &long,
+            TokenizerKind::O200kBase,
+            320,
+            96,
+            UsageSource::Estimated,
+        );
+        assert_token_estimate(
+            &long,
+            TokenizerKind::AnthropicV2,
+            432,
+            130,
+            UsageSource::Estimated,
+        );
+        assert_token_estimate(
+            &long,
+            TokenizerKind::Heuristic,
+            270,
+            81,
+            UsageSource::Heuristic,
+        );
+    }
+
+    #[test]
+    fn tokenizer_mapping_covers_shipped_pricebooks() {
+        let prices_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("../../prices")
+            .canonicalize()
+            .expect("resolve prices dir");
+
+        for file_name in ["anthropic.toml", "openai.toml"] {
+            let file_content =
+                fs::read_to_string(prices_dir.join(file_name)).expect("read pricebook");
+            let parsed: PricebookFile = toml::from_str(&file_content).expect("parse pricebook");
+
+            for entry in parsed.entries {
+                assert_ne!(
+                    tokenizer_kind_for_model(&entry.model_id),
+                    TokenizerKind::Heuristic,
+                    "model {} from {file_name} should have an explicit tokenizer",
+                    entry.model_id
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn tokenizer_mapping_uses_expected_model_families() {
+        assert_eq!(
+            tokenizer_kind_for_model("claude-opus-4-7"),
+            TokenizerKind::AnthropicV2
+        );
+        assert_eq!(
+            tokenizer_kind_for_model("gpt-4o-mini"),
+            TokenizerKind::O200kBase
+        );
+        assert_eq!(
+            tokenizer_kind_for_model("gpt-4.1"),
+            TokenizerKind::Cl100kBase
+        );
+        assert_eq!(tokenizer_kind_for_model("gpt-4"), TokenizerKind::Cl100kBase);
+        assert_eq!(
+            tokenizer_kind_for_model("unknown-local-model"),
+            TokenizerKind::Heuristic
+        );
+    }
+
+    #[test]
+    fn anthropic_and_openai_estimates_diverge_for_same_prompt() {
+        let short = serde_json::json!([
+            { "role": "user", "content": "Hello from PennyPrompt. Estimate this request." }
+        ]);
+        let openai = estimate_tokens_for_model_id("gpt-4.1", &short);
+        let anthropic = estimate_tokens_for_model_id("claude-opus-4-7", &short);
+
+        assert_ne!(openai.input_tokens, anthropic.input_tokens);
+        assert_eq!(openai.source, UsageSource::Estimated);
+        assert_eq!(anthropic.source, UsageSource::Estimated);
+    }
+
+    #[test]
+    fn unknown_models_use_heuristic_tokenizer_without_panicking() {
+        let result = estimate_tokens_for_model_id("unknown-local-model", &short_english_messages());
+
+        assert_eq!(result.input_tokens, 12);
         assert_eq!(result.source, UsageSource::Heuristic);
     }
 

--- a/crates/penny-proxy/src/lib.rs
+++ b/crates/penny-proxy/src/lib.rs
@@ -26,7 +26,7 @@ use penny_config::{
     CleanupConfig as RuntimeCleanupConfig, LoopAction, ScopeType as ConfigScopeType,
     WindowType as ConfigWindowType,
 };
-use penny_cost::{estimate_tokens, PricingEngine};
+use penny_cost::{estimate_tokens_for_model_id, PricingEngine};
 use penny_detect::{DetectEngine, DetectEventRecord, DetectorConfig, SESSION_PAUSED_LOOP_REASON};
 use penny_ledger::CostLedger;
 use penny_providers::{MockProvider, MockProviderConfig, ProviderAdapter, ProviderError};
@@ -601,7 +601,7 @@ fn normalize_chat_request(
     payload: &ChatCompletionsRequest,
 ) -> NormalizedRequest {
     let model = extract_model(&payload.model);
-    let estimate = estimate_tokens(&payload.messages);
+    let estimate = estimate_tokens_for_model_id(&model, &payload.messages);
 
     NormalizedRequest {
         id: ctx.request_id.clone(),

--- a/docs/TECHNICAL_NOTES.md
+++ b/docs/TECHNICAL_NOTES.md
@@ -3,6 +3,37 @@
 This file tracks non-blocking technical recommendations that should remain visible
 without stopping milestone delivery.
 
+## 2026-06: Alpha.3 Tokenizer Dispatch (`#184`)
+
+Decision:
+- `penny-cost` resolves a `TokenizerKind` from each model id before estimating
+  input tokens.
+- OpenAI `gpt-4.1*` uses `cl100k_base`.
+- OpenAI `gpt-4o*` uses `o200k_base`.
+- Anthropic `claude-*` uses an alpha heuristic named `AnthropicV2`: count with
+  `cl100k_base`, then apply a `1.35` multiplier and round up.
+- Unknown models use the existing `chars/4` heuristic instead of panicking.
+
+Rationale:
+- There is no stable first-party Rust Anthropic tokenizer dependency in the
+  current project graph.
+- The `1.35` multiplier matches the alpha audit finding that Claude Opus 4.7
+  can report materially more tokens than `cl100k_base` on equivalent prompts.
+- The heuristic is deliberately conservative for pre-call estimates; provider
+  reconciliation remains authoritative when real usage is returned.
+
+Calibration fixtures:
+- Empty message array: all tokenizers fall back to 1 heuristic input token.
+- Short English prompt: `cl100k_base`/`o200k_base` = 9 input tokens,
+  `AnthropicV2` = 13, `Heuristic` = 12.
+- Repeated Rust code block: `cl100k_base`/`o200k_base` = 320 input tokens,
+  `AnthropicV2` = 432, `Heuristic` = 270.
+
+Upgrade path:
+- Replace `AnthropicV2` with an official/local Anthropic tokenizer when a
+  stable Rust option is available.
+- Keep fixture tests so the switch is intentional and reviewable.
+
 ## 2026-04: Gemini Non-Blocking Recommendations (`#94`)
 
 Source reviews:


### PR DESCRIPTION
## Summary
- add public TokenizerKind mapping in penny-cost for cl100k, o200k, AnthropicV2, and heuristic fallback
- route proxy/admin/CLI pre-call estimates through model-aware token estimation
- cover shipped pricebooks so active models do not fall back to heuristic
- document the AnthropicV2 alpha decision: cl100k count * 1.35, rounded up, until a stable Rust Anthropic tokenizer is available

Closes #184

## Validation
- cargo fmt --all -- --check
- cargo test -p penny-cost --locked
- cargo check --workspace --locked
- cargo clippy --workspace --all-targets --locked -- -D warnings
- cargo test -p penny-cli estimate_context_from_context_files_glob --locked
- cargo test -p penny-admin estimate_endpoint_returns_range_route_and_budget_summary --locked
- cargo test -p penny-proxy normalization_extracts_model_stream_and_token_hook_fields --locked

## Not run
- HOME=/private/tmp/pennyprompt-audit-home RUSTUP_HOME=/Users/mpz/.rustup CARGO_HOME=/Users/mpz/.cargo cargo test --workspace --locked; escalated run was rejected by the environment usage limit, so I did not retry it via another route.
