### PR TITLE
feat: add cli help descriptions

### DIFF
--- a/crates/penny-cli/src/main.rs
+++ b/crates/penny-cli/src/main.rs
@@ -57,25 +57,31 @@ struct Cli {
 
 #[derive(Debug, Subcommand)]
 enum Commands {
+    #[command(about = "initialize local config, database, budgets, and pricebooks")]
     Init {
         #[arg(long, default_value = PRESET_INDIE)]
         preset: String,
         #[arg(long, default_value_t = false)]
         force: bool,
     },
+    #[command(about = "check config, database, provider keys, pricebook freshness, and binds")]
     Doctor,
+    #[command(about = "print resolved configuration")]
     Config {
         #[arg(long, default_value_t = false)]
         json: bool,
     },
+    #[command(about = "inspect or update local model pricebooks")]
     Prices {
         #[command(subcommand)]
         command: PricesCommands,
     },
+    #[command(about = "list, set, or reset local budget guardrails")]
     Budget {
         #[command(subcommand)]
         command: BudgetCommands,
     },
+    #[command(about = "estimate token and cost range before running work")]
     Estimate {
         #[arg(long)]
         model: String,
@@ -92,10 +98,12 @@ enum Commands {
         #[arg(long, default_value_t = 200)]
         max_files: usize,
     },
+    #[command(about = "inspect or resume detector-paused sessions")]
     Detect {
         #[command(subcommand)]
         command: DetectCommands,
     },
+    #[command(about = "preview launcher attribution and runtime wiring (dry-run plan only)")]
     Run {
         agent: String,
         #[arg(long, default_value_t = false)]
@@ -109,6 +117,7 @@ enum Commands {
         #[arg(long, default_value_t = false)]
         json: bool,
     },
+    #[command(about = "start proxy and admin planes")]
     Serve {
         #[arg(long, default_value_t = false)]
         mock: bool,
@@ -120,6 +129,7 @@ enum Commands {
         )]
         admin_bind: Option<String>,
     },
+    #[command(about = "stream admin events from the local control plane")]
     Tail {
         #[arg(
             long,
@@ -136,10 +146,12 @@ enum Commands {
         #[arg(long, default_value_t = false)]
         once: bool,
     },
+    #[command(about = "summarize persisted request cost data")]
     Report {
         #[command(subcommand)]
         command: ReportCommands,
     },
+    #[command(about = "render a compact local cost dashboard")]
     Dashboard {
         #[arg(long)]
         since: Option<String>,
@@ -150,6 +162,7 @@ enum Commands {
 
 #[derive(Debug, Subcommand)]
 enum ReportCommands {
+    #[command(about = "summarize requests by project, model, or session")]
     Summary {
         #[arg(long)]
         since: Option<String>,
@@ -158,6 +171,7 @@ enum ReportCommands {
         #[arg(long, value_enum, default_value_t = SummaryFormat::Table)]
         format: SummaryFormat,
     },
+    #[command(about = "show highest-cost requests")]
     Top {
         #[arg(long, default_value_t = 20)]
         limit: u32,
@@ -166,6 +180,7 @@ enum ReportCommands {
 
 #[derive(Debug, Subcommand)]
 enum DetectCommands {
+    #[command(about = "show detector status, active alerts, and paused sessions")]
     Status {
         #[arg(
             long,
@@ -174,6 +189,7 @@ enum DetectCommands {
         )]
         admin_url: String,
     },
+    #[command(about = "resume a paused session")]
     Resume {
         session_id: String,
         #[arg(long)]
@@ -189,16 +205,20 @@ enum DetectCommands {
 
 #[derive(Debug, Subcommand)]
 enum PricesCommands {
+    #[command(about = "show active model prices")]
     Show {
         #[arg(long, default_value_t = 20)]
         limit: u32,
     },
+    #[command(about = "import bundled local pricebooks")]
     Update,
 }
 
 #[derive(Debug, Subcommand)]
 enum BudgetCommands {
+    #[command(about = "list configured runtime budgets")]
     List,
+    #[command(about = "set or update a runtime budget")]
     Set {
         #[arg(long, value_enum)]
         scope_type: BudgetScopeArg,
@@ -215,6 +235,7 @@ enum BudgetCommands {
         #[arg(long, default_value = "warn")]
         action_on_soft: String,
     },
+    #[command(about = "remove a runtime budget")]
     Reset {
         #[arg(long, value_enum)]
         scope_type: BudgetScopeArg,

--- a/crates/penny-cli/tests/help_output.rs
+++ b/crates/penny-cli/tests/help_output.rs
@@ -1,0 +1,89 @@
+use std::process::Command;
+
+fn help_output(args: &[&str]) -> String {
+    let output = Command::new(env!("CARGO_BIN_EXE_penny-cli"))
+        .args(args)
+        .output()
+        .expect("run penny-cli help");
+
+    assert!(
+        output.status.success(),
+        "help command failed: status={:?}, stderr={}",
+        output.status.code(),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    String::from_utf8(output.stdout).expect("help output is utf-8")
+}
+
+fn assert_contains_all(output: &str, expected: &[&str]) {
+    for text in expected {
+        assert!(
+            output.contains(text),
+            "expected help output to contain `{text}`\n\n{output}"
+        );
+    }
+}
+
+#[test]
+fn root_help_lists_descriptions_for_top_level_commands() {
+    let output = help_output(&["--help"]);
+
+    assert_contains_all(
+        &output,
+        &[
+            "initialize local config, database, budgets, and pricebooks",
+            "check config, database, provider keys, pricebook freshness, and binds",
+            "print resolved configuration",
+            "inspect or update local model pricebooks",
+            "list, set, or reset local budget guardrails",
+            "estimate token and cost range before running work",
+            "inspect or resume detector-paused sessions",
+            "preview launcher attribution and runtime wiring (dry-run plan only)",
+            "start proxy and admin planes",
+            "stream admin events from the local control plane",
+            "summarize persisted request cost data",
+            "render a compact local cost dashboard",
+        ],
+    );
+}
+
+#[test]
+fn nested_help_lists_descriptions_for_command_groups() {
+    let cases = [
+        (
+            ["prices", "--help"],
+            &[
+                "show active model prices",
+                "import bundled local pricebooks",
+            ][..],
+        ),
+        (
+            ["budget", "--help"],
+            &[
+                "list configured runtime budgets",
+                "set or update a runtime budget",
+                "remove a runtime budget",
+            ][..],
+        ),
+        (
+            ["detect", "--help"],
+            &[
+                "show detector status, active alerts, and paused sessions",
+                "resume a paused session",
+            ][..],
+        ),
+        (
+            ["report", "--help"],
+            &[
+                "summarize requests by project, model, or session",
+                "show highest-cost requests",
+            ][..],
+        ),
+    ];
+
+    for (args, expected) in cases {
+        let output = help_output(&args);
+        assert_contains_all(&output, expected);
+    }
+}


### PR DESCRIPTION
## Summary
- add one-line clap descriptions to every top-level penny-cli subcommand
- add descriptions to prices, budget, detect, and report nested commands
- add integration tests that execute real --help output for root and nested groups

Closes #183

## Validation
- cargo fmt --all -- --check
- cargo test -p penny-cli --locked
- cargo clippy -p penny-cli --all-targets --locked -- -D warnings
- git diff --check -- crates/penny-cli/src/main.rs crates/penny-cli/tests/help_output.rs
