### PR TITLE
feat: add structured proxy tracing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1498,6 +1498,7 @@ dependencies = [
  "tokio-stream",
  "tower",
  "tracing",
+ "tracing-subscriber",
  "uuid",
 ]
 

--- a/crates/penny-proxy/Cargo.toml
+++ b/crates/penny-proxy/Cargo.toml
@@ -31,3 +31,4 @@ async-trait = "0.1"
 tempfile = "3"
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 tower = { version = "0.5", features = ["util"] }
+tracing-subscriber = "0.3"

--- a/crates/penny-proxy/src/lib.rs
+++ b/crates/penny-proxy/src/lib.rs
@@ -47,7 +47,7 @@ use tokio::net::TcpListener;
 use tokio::sync::mpsc;
 use tokio::time::timeout;
 use tokio_stream::wrappers::ReceiverStream;
-use tracing::error;
+use tracing::{error, field, info, info_span, Instrument, Span};
 use uuid::Uuid;
 
 pub const DEFAULT_PROXY_BIND: &str = "127.0.0.1:8585";
@@ -324,6 +324,29 @@ async fn post_chat_completions(
     headers: HeaderMap,
     Json(payload): Json<ChatCompletionsRequest>,
 ) -> Response {
+    let request_id = ctx.request_id.clone();
+    let model = extract_model(&payload.model);
+    let provider = state.provider.provider_id().to_string();
+    let span = info_span!(
+        "proxy.request",
+        request_id = %request_id,
+        session_id = field::Empty,
+        model = %model,
+        provider = %provider
+    );
+
+    async move { post_chat_completions_instrumented(state, ctx, headers, payload).await }
+        .instrument(span)
+        .await
+}
+
+async fn post_chat_completions_instrumented(
+    state: Arc<ProxyState>,
+    ctx: RequestContext,
+    headers: HeaderMap,
+    payload: ChatCompletionsRequest,
+) -> Response {
+    let request_started_at = Instant::now();
     if let Err(message) = validate_chat_request(&payload) {
         return error_response(StatusCode::BAD_REQUEST, "invalid_request", message);
     }
@@ -342,6 +365,8 @@ async fn post_chat_completions(
     };
     normalized.project_id = project_id;
     normalized.session_id = session_id;
+    Span::current().record("session_id", field::display(&normalized.session_id));
+    info!(target: "proxy.request", "received");
 
     if state.detector.is_session_paused(&normalized.session_id) {
         let reason = state
@@ -359,6 +384,15 @@ async fn post_chat_completions(
         Ok(context) => context,
         Err(response) => return response,
     };
+    if let Some(context) = enforcement.as_ref() {
+        if context.reserve_persisted {
+            info!(
+                target: "proxy.budget",
+                reserved_usd = %context.estimated_cost_usd,
+                "reserved"
+            );
+        }
+    }
 
     let provider_response = match state.provider.send(normalized.clone()).await {
         Ok(response) => response,
@@ -416,6 +450,11 @@ async fn post_chat_completions(
                     )
                     .await;
                 }
+                log_request_failure(
+                    status,
+                    "upstream_http",
+                    format!("upstream returned HTTP {}", status.as_u16()),
+                );
                 return (status, Json(value)).into_response();
             }
 
@@ -426,6 +465,15 @@ async fn post_chat_completions(
             let usage_cost_usd =
                 compute_usage_cost_or_fallback(&state, &normalized, &usage, enforcement.as_ref())
                     .await;
+            let latency_ms = request_started_at.elapsed().as_millis() as u64;
+            info!(
+                target: "proxy.completion",
+                input_tokens = usage.input_tokens,
+                output_tokens = usage.output_tokens,
+                cost_usd = %usage_cost_usd,
+                latency_ms,
+                "completed"
+            );
             if let Some(context) = enforcement {
                 if let Err(message) = reconcile_after_dispatch(
                     &state,
@@ -443,6 +491,12 @@ async fn post_chat_completions(
                     );
                 }
             }
+            info!(
+                target: "proxy.ledger",
+                reconciled_usd = %usage_cost_usd,
+                source = ?usage.source,
+                "reconciled"
+            );
             if let Err(message) =
                 persist_request_and_usage(&state, &normalized, &usage, usage_cost_usd).await
             {
@@ -470,6 +524,7 @@ async fn post_chat_completions(
                     normalized.clone(),
                     enforcement,
                     receiver,
+                    request_started_at,
                 )
                 .await
             } else if let Some(lines) = state.provider.stream_response_lines(&normalized) {
@@ -487,6 +542,7 @@ async fn post_chat_completions(
                     normalized.clone(),
                     enforcement,
                     rx,
+                    request_started_at,
                 )
                 .await
             } else {
@@ -982,10 +1038,10 @@ async fn evaluate_budget_before_dispatch(
         Ok(value) => value,
         Err(message) => {
             if matches!(state.mode, Mode::Guard) {
-                log_internal_error("budget_engine_has_any_budget_failed", message);
-                return Err(budget_error_response(
+                return Err(budget_internal_error_response(
                     "budget_engine_failure",
                     "budget engine temporarily unavailable".to_string(),
+                    message,
                     None,
                 ));
             }
@@ -1004,10 +1060,10 @@ async fn evaluate_budget_before_dispatch(
         Ok(cost) => cost,
         Err(message) => {
             if matches!(state.mode, Mode::Guard) {
-                log_internal_error("budget_engine_estimated_cost_failed", message);
-                return Err(budget_error_response(
+                return Err(budget_internal_error_response(
                     "budget_engine_failure",
                     "budget engine temporarily unavailable".to_string(),
+                    message,
                     None,
                 ));
             }
@@ -1037,10 +1093,10 @@ async fn evaluate_budget_before_dispatch(
         }
         RouteDecision::Failsafe { mode, reason } => {
             if matches!(mode, Mode::Guard) {
-                log_internal_error("budget_engine_guard_failsafe", reason);
-                Err(budget_error_response(
+                Err(budget_internal_error_response(
                     "budget_engine_failure",
                     "budget engine fail-closed in guard mode".to_string(),
+                    reason,
                     None,
                 ))
             } else {
@@ -1200,68 +1256,89 @@ async fn stream_passthrough_response(
     normalized: NormalizedRequest,
     enforcement: Option<BudgetEnforcementContext>,
     mut upstream: mpsc::Receiver<String>,
+    request_started_at: Instant,
 ) -> Response {
     let (client_tx, client_rx) = mpsc::channel::<Result<Bytes, Infallible>>(64);
-    tokio::spawn(async move {
-        let mut lines = Vec::new();
-        let mut cleanup_metrics = CleanupMetrics::default();
-        let mut saw_done = false;
-        while let Some(line) = upstream.recv().await {
-            let (line, line_metrics) = cleanup_sse_line(&line, state.cleanup);
-            cleanup_metrics.merge(line_metrics);
-            if line.trim().eq_ignore_ascii_case("data: [done]") {
-                saw_done = true;
+    let request_span = Span::current();
+    tokio::spawn(
+        async move {
+            let mut lines = Vec::new();
+            let mut cleanup_metrics = CleanupMetrics::default();
+            let mut saw_done = false;
+            while let Some(line) = upstream.recv().await {
+                let (line, line_metrics) = cleanup_sse_line(&line, state.cleanup);
+                cleanup_metrics.merge(line_metrics);
+                if line.trim().eq_ignore_ascii_case("data: [done]") {
+                    saw_done = true;
+                }
+                lines.push(line.clone());
+                if client_tx.send(Ok(Bytes::from(line))).await.is_err() {
+                    break;
+                }
+                if saw_done {
+                    break;
+                }
             }
-            lines.push(line.clone());
-            if client_tx.send(Ok(Bytes::from(line))).await.is_err() {
-                break;
-            }
-            if saw_done {
-                break;
-            }
-        }
 
-        let mut usage = provider_usage_from_sse_lines(&lines)
-            .unwrap_or_else(|| estimated_usage_from_request(&normalized));
-        attach_cleanup_metrics(&mut usage, state.cleanup, cleanup_metrics);
-        if !saw_done {
-            mark_stream_incomplete(&mut usage);
-            log_provider_failure_event(
-                &state,
-                &normalized,
-                status,
-                "incomplete_stream",
-                &json!({"message":"upstream stream ended before [DONE]"}),
-            )
-            .await;
-        }
+            let mut usage = provider_usage_from_sse_lines(&lines)
+                .unwrap_or_else(|| estimated_usage_from_request(&normalized));
+            attach_cleanup_metrics(&mut usage, state.cleanup, cleanup_metrics);
+            if !saw_done {
+                mark_stream_incomplete(&mut usage);
+                log_provider_failure_event(
+                    &state,
+                    &normalized,
+                    status,
+                    "incomplete_stream",
+                    &json!({"message":"upstream stream ended before [DONE]"}),
+                )
+                .await;
+            }
 
-        let usage_cost_usd =
-            compute_usage_cost_or_fallback(&state, &normalized, &usage, enforcement.as_ref()).await;
-        if let Some(context) = enforcement {
-            if let Err(message) = reconcile_after_dispatch(
-                &state,
-                &normalized.id,
-                usage_cost_usd,
-                context.reserve_persisted,
-            )
-            .await
+            let usage_cost_usd =
+                compute_usage_cost_or_fallback(&state, &normalized, &usage, enforcement.as_ref())
+                    .await;
+            let latency_ms = request_started_at.elapsed().as_millis() as u64;
+            info!(
+                target: "proxy.completion",
+                input_tokens = usage.input_tokens,
+                output_tokens = usage.output_tokens,
+                cost_usd = %usage_cost_usd,
+                latency_ms,
+                "completed"
+            );
+            if let Some(context) = enforcement {
+                if let Err(message) = reconcile_after_dispatch(
+                    &state,
+                    &normalized.id,
+                    usage_cost_usd,
+                    context.reserve_persisted,
+                )
+                .await
+                {
+                    log_internal_error("ledger_reconcile_failed", message);
+                }
+            }
+            info!(
+                target: "proxy.ledger",
+                reconciled_usd = %usage_cost_usd,
+                source = ?usage.source,
+                "reconciled"
+            );
+            if let Err(message) =
+                persist_request_and_usage(&state, &normalized, &usage, usage_cost_usd).await
             {
-                log_internal_error("ledger_reconcile_failed", message);
+                log_internal_error("persistence_failed", message);
             }
+            spawn_detection_after_reconcile(
+                state.clone(),
+                normalized.clone(),
+                usage.clone(),
+                usage_cost_usd,
+            );
         }
-        if let Err(message) =
-            persist_request_and_usage(&state, &normalized, &usage, usage_cost_usd).await
-        {
-            log_internal_error("persistence_failed", message);
-        }
-        spawn_detection_after_reconcile(
-            state.clone(),
-            normalized.clone(),
-            usage.clone(),
-            usage_cost_usd,
-        );
-    });
+        .instrument(request_span),
+    );
 
     let mut response = Response::builder()
         .status(status)
@@ -1536,6 +1613,11 @@ fn header_value(headers: &HeaderMap, name: &str) -> Option<String> {
 }
 
 fn error_response(status: StatusCode, code: &'static str, message: String) -> Response {
+    log_request_failure(status, code, message.clone());
+    api_error_response(status, code, message)
+}
+
+fn api_error_response(status: StatusCode, code: &'static str, message: String) -> Response {
     (
         status,
         Json(json!(ApiError {
@@ -1551,11 +1633,30 @@ fn internal_error_response(
     public_message: String,
     internal_detail: String,
 ) -> Response {
-    log_internal_error(code, internal_detail);
-    error_response(status, code, public_message)
+    log_request_failure(status, code, internal_detail);
+    api_error_response(status, code, public_message)
 }
 
 fn budget_error_response(
+    error_type: &'static str,
+    message: String,
+    budget: Option<BudgetBlockDetail>,
+) -> Response {
+    log_request_failure(StatusCode::PAYMENT_REQUIRED, error_type, message.clone());
+    budget_error_body(error_type, message, budget)
+}
+
+fn budget_internal_error_response(
+    error_type: &'static str,
+    public_message: String,
+    internal_detail: String,
+    budget: Option<BudgetBlockDetail>,
+) -> Response {
+    log_request_failure(StatusCode::PAYMENT_REQUIRED, error_type, internal_detail);
+    budget_error_body(error_type, public_message, budget)
+}
+
+fn budget_error_body(
     error_type: &'static str,
     message: String,
     budget: Option<BudgetBlockDetail>,
@@ -1574,8 +1675,18 @@ fn budget_error_response(
         .into_response()
 }
 
+fn log_request_failure(status: StatusCode, tag: &str, detail: String) {
+    error!(
+        target: "proxy.error",
+        tag = tag,
+        detail = %detail,
+        status = status.as_u16(),
+        "failed"
+    );
+}
+
 fn log_internal_error(tag: &str, detail: String) {
-    error!(tag = tag, detail = %detail, "internal proxy error");
+    error!(target: "proxy.error", tag = tag, detail = %detail, "failed");
 }
 
 #[cfg(test)]
@@ -1604,7 +1715,6 @@ mod tests {
     use tokio::sync::mpsc;
     use tokio::time::{sleep, Duration};
     use tower::ServiceExt;
-
     fn app() -> Router {
         build_router(ProxyState::mock_default())
     }

--- a/crates/penny-proxy/tests/structured_tracing.rs
+++ b/crates/penny-proxy/tests/structured_tracing.rs
@@ -1,0 +1,274 @@
+use std::collections::BTreeMap;
+use std::sync::{Arc, Mutex, OnceLock};
+
+use axum::{
+    body::Body,
+    http::{header, Request, StatusCode},
+};
+use penny_proxy::{build_router, ProxyState};
+use serde_json::json;
+use tower::ServiceExt;
+use tracing::field::{Field, Visit};
+use tracing::span::{Attributes, Record};
+use tracing::{Event, Id, Subscriber};
+use tracing_subscriber::layer::{Context, Layer};
+use tracing_subscriber::prelude::*;
+use tracing_subscriber::registry::LookupSpan;
+
+const SESSION_OVERRIDE_HEADER: &str = "x-penny-session";
+
+#[derive(Clone, Default)]
+struct CapturedLayer {
+    events: Arc<Mutex<Vec<CapturedEvent>>>,
+}
+
+#[derive(Debug, Clone)]
+struct CapturedEvent {
+    target: String,
+    fields: BTreeMap<String, String>,
+}
+
+#[derive(Debug, Default, Clone)]
+struct FieldMap(BTreeMap<String, String>);
+
+impl Visit for FieldMap {
+    fn record_debug(&mut self, field: &Field, value: &dyn std::fmt::Debug) {
+        let rendered = format!("{value:?}");
+        self.0.insert(
+            field.name().to_string(),
+            rendered.trim_matches('"').to_string(),
+        );
+    }
+
+    fn record_str(&mut self, field: &Field, value: &str) {
+        self.0.insert(field.name().to_string(), value.to_string());
+    }
+
+    fn record_i64(&mut self, field: &Field, value: i64) {
+        self.0.insert(field.name().to_string(), value.to_string());
+    }
+
+    fn record_u64(&mut self, field: &Field, value: u64) {
+        self.0.insert(field.name().to_string(), value.to_string());
+    }
+
+    fn record_bool(&mut self, field: &Field, value: bool) {
+        self.0.insert(field.name().to_string(), value.to_string());
+    }
+}
+
+impl<S> Layer<S> for CapturedLayer
+where
+    S: Subscriber + for<'lookup> LookupSpan<'lookup>,
+{
+    fn on_new_span(&self, attrs: &Attributes<'_>, id: &Id, ctx: Context<'_, S>) {
+        let mut fields = FieldMap::default();
+        attrs.record(&mut fields);
+        if let Some(span) = ctx.span(id) {
+            span.extensions_mut().insert(fields);
+        }
+    }
+
+    fn on_record(&self, id: &Id, values: &Record<'_>, ctx: Context<'_, S>) {
+        let mut fields = FieldMap::default();
+        values.record(&mut fields);
+        if let Some(span) = ctx.span(id) {
+            let mut extensions = span.extensions_mut();
+            if let Some(existing) = extensions.get_mut::<FieldMap>() {
+                existing.0.extend(fields.0);
+            } else {
+                extensions.insert(fields);
+            }
+        }
+    }
+
+    fn on_event(&self, event: &Event<'_>, ctx: Context<'_, S>) {
+        let mut fields = BTreeMap::new();
+        if let Some(scope) = ctx.event_scope(event) {
+            for span in scope.from_root() {
+                if let Some(span_fields) = span.extensions().get::<FieldMap>() {
+                    for (key, value) in &span_fields.0 {
+                        fields.entry(key.clone()).or_insert_with(|| value.clone());
+                    }
+                }
+            }
+        }
+
+        let mut event_fields = FieldMap::default();
+        event.record(&mut event_fields);
+        fields.extend(event_fields.0);
+
+        self.events
+            .lock()
+            .expect("captured event lock")
+            .push(CapturedEvent {
+                target: event.metadata().target().to_string(),
+                fields,
+            });
+    }
+}
+
+fn global_trace_capture() -> CapturedLayer {
+    static LAYER: OnceLock<CapturedLayer> = OnceLock::new();
+    LAYER
+        .get_or_init(|| {
+            let layer = CapturedLayer::default();
+            let subscriber = tracing_subscriber::registry()
+                .with(tracing_subscriber::filter::LevelFilter::TRACE)
+                .with(layer.clone());
+            tracing::subscriber::set_global_default(subscriber)
+                .expect("install test tracing subscriber");
+            layer
+        })
+        .clone()
+}
+
+fn clear_captured_events(layer: &CapturedLayer) {
+    layer.events.lock().expect("captured event lock").clear();
+}
+
+fn captured_events(layer: &CapturedLayer) -> Vec<CapturedEvent> {
+    layer.events.lock().expect("captured event lock").clone()
+}
+
+fn event_with_message<'a>(
+    events: &'a [CapturedEvent],
+    target: &str,
+    message: &str,
+) -> &'a CapturedEvent {
+    events
+        .iter()
+        .find(|event| {
+            event.target == target
+                && event
+                    .fields
+                    .get("message")
+                    .is_some_and(|value| value.contains(message))
+        })
+        .unwrap_or_else(|| panic!("missing event target={target} message={message}: {events:?}"))
+}
+
+fn assert_success_span_fields(event: &CapturedEvent, session_id: &str) {
+    assert!(event
+        .fields
+        .get("request_id")
+        .is_some_and(|value| !value.is_empty()));
+    assert_eq!(
+        event.fields.get("session_id").map(String::as_str),
+        Some(session_id)
+    );
+    assert_eq!(
+        event.fields.get("model").map(String::as_str),
+        Some("claude-sonnet-4-6")
+    );
+    assert_eq!(
+        event.fields.get("provider").map(String::as_str),
+        Some("mock")
+    );
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn structured_tracing_emits_success_hot_path_events() {
+    let layer = global_trace_capture();
+    clear_captured_events(&layer);
+    let trace_session_id = "trace-session-success";
+    let response = build_router(ProxyState::mock_default())
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/chat/completions")
+                .header(header::CONTENT_TYPE, "application/json")
+                .header(SESSION_OVERRIDE_HEADER, trace_session_id)
+                .body(Body::from(
+                    json!({
+                        "model": "claude-sonnet-4-6",
+                        "messages": [{"role": "user", "content": "hello"}]
+                    })
+                    .to_string(),
+                ))
+                .expect("request"),
+        )
+        .await
+        .expect("response");
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let events = captured_events(&layer);
+    let request_events = events
+        .iter()
+        .filter(|event| {
+            event.fields.get("session_id").map(String::as_str) == Some(trace_session_id)
+        })
+        .cloned()
+        .collect::<Vec<_>>();
+    let received = event_with_message(&request_events, "proxy.request", "received");
+    let completed = event_with_message(&request_events, "proxy.completion", "completed");
+    let reconciled = event_with_message(&request_events, "proxy.ledger", "reconciled");
+
+    assert_success_span_fields(received, trace_session_id);
+    assert_success_span_fields(completed, trace_session_id);
+    assert_success_span_fields(reconciled, trace_session_id);
+    assert_eq!(
+        completed.fields.get("input_tokens").map(String::as_str),
+        Some("120")
+    );
+    assert_eq!(
+        completed.fields.get("output_tokens").map(String::as_str),
+        Some("48")
+    );
+    assert!(completed.fields.contains_key("cost_usd"));
+    assert!(completed.fields.contains_key("latency_ms"));
+    assert!(reconciled.fields.contains_key("reconciled_usd"));
+    assert_eq!(
+        reconciled.fields.get("source").map(String::as_str),
+        Some("Provider")
+    );
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn structured_tracing_emits_one_error_event_for_invalid_request() {
+    let layer = global_trace_capture();
+    clear_captured_events(&layer);
+    let trace_model = "trace-invalid-model";
+    let response = build_router(ProxyState::mock_default())
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/chat/completions")
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(Body::from(
+                    json!({
+                        "model": trace_model,
+                        "messages": "invalid"
+                    })
+                    .to_string(),
+                ))
+                .expect("request"),
+        )
+        .await
+        .expect("response");
+
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    let events = captured_events(&layer);
+    let errors = events
+        .iter()
+        .filter(|event| {
+            event.target == "proxy.error"
+                && event.fields.get("model").map(String::as_str) == Some(trace_model)
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(errors.len(), 1, "unexpected error events: {events:?}");
+    let error = errors[0];
+    assert_eq!(
+        error.fields.get("tag").map(String::as_str),
+        Some("invalid_request")
+    );
+    assert_eq!(error.fields.get("status").map(String::as_str), Some("400"));
+    assert!(error
+        .fields
+        .get("request_id")
+        .is_some_and(|value| !value.is_empty()));
+    assert_eq!(
+        error.fields.get("provider").map(String::as_str),
+        Some("mock")
+    );
+}


### PR DESCRIPTION
Closes #185.

## Summary
- Adds a `proxy.request` span with `request_id`, `session_id`, `model`, and `provider` context.
- Emits structured hot-path events for request receipt, budget reservation, completion accounting, ledger reconciliation, and failures.
- Adds integration coverage under `crates/penny-proxy/tests/structured_tracing.rs` for success and invalid-request error paths.

## Validation
- `cargo fmt --all -- --check`
- `git diff --check`
- `env HOME=/private/tmp/pennyprompt-audit-home RUSTUP_HOME=/Users/mpz/.rustup CARGO_HOME=/Users/mpz/.cargo cargo test -p penny-proxy --locked`
- `env HOME=/private/tmp/pennyprompt-audit-home RUSTUP_HOME=/Users/mpz/.rustup CARGO_HOME=/Users/mpz/.cargo cargo clippy --workspace --all-targets --locked -- -D warnings`

Manual JSON-log smoke with `penny-cli --json-log serve --mock` produced parsable per-request JSON. Sample completion line:

```json
{"level":"INFO","fields":{"message":"completed","input_tokens":120,"output_tokens":48,"cost_usd":"0.001080","latency_ms":43},"target":"proxy.completion","span":{"model":"claude-sonnet-4-6","provider":"mock","request_id":"...","session_id":"...","name":"proxy.request"}}
```
