### PR TITLE
release: prepare alpha3 gate and notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,20 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+No unreleased changes.
+
+## [v0.1.0-alpha.3] - 2026-06-20
+
 ### Added
-- Upcoming changes are tracked via issue-first workflow and merged through PRs.
-- Alpha.2 release gate artifacts: targeted checklist, linked release process gate, and release notes document.
+- CLI help text now includes descriptions for root and nested subcommands (`#183`).
+- Proxy hot-path tracing now emits structured `proxy.request`, `proxy.budget`, `proxy.completion`, `proxy.ledger`, and `proxy.error` events for JSON-log operators (`#185`).
+- CI now runs `cargo audit` as part of the standard gate, with the non-applicable `rsa` advisory documented inline (`#189`).
+- Alpha.3 release gate and release notes documents for the final pre-tag checklist (`#196`).
 
 ### Changed
+- `penny-cost` now dispatches token estimation by model family instead of using one OpenAI tokenizer path for every model (`#184`).
+- TLS verification dependencies were refreshed, including `rustls-webpki`, before the alpha.3 cut (`#189`).
+- Admin-plane security docs now describe the actual alpha contract: local-only Unix socket or loopback TCP, with no bearer/admin-token auth claim (`#190`).
 - Observability startup precedence is now explicit: CLI flags (`--log-filter`, `--json-log`) override environment (`PENNY_LOG`/`RUST_LOG`, `PENNY_OBSERVE_JSON`), which still override built-in defaults. Backward-compatibility note: workflows relying on env vars to force logging behavior should stop passing conflicting CLI flags.
 
 ## [v0.1.0-alpha.2] - 2026-04-30

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1373,7 +1373,7 @@ dependencies = [
 
 [[package]]
 name = "penny-cli"
-version = "0.1.0"
+version = "0.1.0-alpha.3"
 dependencies = [
  "chrono",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,5 +18,4 @@ resolver = "2"
 [workspace.package]
 edition = "2021"
 license = "MIT"
-version = "0.1.0"
-
+version = "0.1.0-alpha.3"

--- a/crates/penny-cli/Cargo.toml
+++ b/crates/penny-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "penny-cli"
-version = "0.1.0"
+version = "0.1.0-alpha.3"
 edition = "2021"
 publish = false
 

--- a/docs/GITHUB_BACKLOG.md
+++ b/docs/GITHUB_BACKLOG.md
@@ -8,11 +8,11 @@ automation all exist.
 Current baseline:
 - Branch: `main`
 - Latest published release: `v0.1.0-alpha.2` published on 2026-05-15 as a GitHub prerelease.
-- Open PRs at the 2026-06-19 audit: none.
-- Active roadmap: `v0.1.0-alpha.3` hardening release.
+- Capture date: 2026-06-20 after `#183`, `#184`, `#185`, `#189`, and `#190` closed.
+- Active roadmap: final `v0.1.0-alpha.3` release-prep and publish gate.
 
 Source of truth for this backlog:
-- GitHub issues `#183`, `#184`, `#185`, and `#186`.
+- GitHub issues `#186` and `#196`, plus closed release blockers `#183`, `#184`, `#185`, `#189`, and `#190`.
 - `docs/status-2026-05-07.md`.
 - `docs/CONFIG-REFERENCE.md`.
 - `docs/RELEASE.md`.
@@ -62,115 +62,55 @@ Out of scope for alpha.3:
 - `#186` - `[Epic] v0.1.0-alpha.3 release scope`
 
 Definition:
-- Close the implementation hardening issues.
-- Fix release blockers discovered during the 2026-06-19 audit.
 - Cut and publish `v0.1.0-alpha.3`.
+- Close once version bump, changelog, release gate, release notes, tag, GitHub Release, and artifact verification are complete.
 
-### Required Child Issues
+### Release Prep
 
-1. `#184` - `feat(cost): per-model tokenizer dispatch (Anthropic vs OpenAI families)`
+- `#196` - `release: prepare v0.1.0-alpha.3 gate and notes`
 
-Why it matters:
-- `penny-cost` currently estimates all textual input with `cl100k_base`.
-- Anthropic-family estimates can be materially low.
-- Low estimates bias `estimate` output and budget reservations.
+Definition:
+- Prepare version bump, changelog, release gate, release notes, and release-process docs.
+- Close through the release-prep PR before tagging.
 
-Acceptance:
-- `TokenizerKind` or equivalent exists.
-- Active shipped pricebook models resolve to a non-heuristic tokenizer class.
-- Unknown models use a safe heuristic fallback.
-- Tests cover OpenAI, Anthropic, and fallback behavior.
-- `docs/TECHNICAL_NOTES.md` records the Anthropic tokenizer decision.
+### Closed Alpha.3 Implementation Scope
 
-2. `#185` - `feat(proxy): structured tracing on request hot path (info spans + per-stage events)`
+- `#183` - `feat(cli): add --help descriptions to every subcommand`
+- `#184` - `feat(cost): per-model tokenizer dispatch (Anthropic vs OpenAI families)`
+- `#185` - `feat(proxy): structured tracing on request hot path (info spans + per-stage events)`
+- `#189` - `security: refresh rustls-webpki and add cargo audit release gate`
+- `#190` - `docs(security): align admin plane security contract with implementation`
 
-Why it matters:
-- Runtime accounting exists, but the proxy hot path has too little structured log evidence.
-- Operators need request, model, provider, cost, latency, and outcome fields in JSON logs.
+### Remaining Release Work After `#196`
 
-Acceptance:
-- Successful requests emit structured `received`, `completed`, and `reconciled` events.
-- Error paths emit one structured error event with request context.
-- Proxy tests assert the structured field set.
-- Manual `--json-log` evidence is attached to the PR.
-
-3. `#183` - `feat(cli): add --help descriptions to every subcommand`
-
-Why it matters:
-- First-run CLI help is still too bare for alpha users.
-- This is a low-risk UX improvement that makes the release more credible.
-
-Acceptance:
-- Root help and nested help groups show useful descriptions.
-- Golden/snapshot tests cover root and at least one nested group.
-- No command behavior changes.
-
-## New Release Blockers From 2026-06-19 Audit
-
-These should be filed as GitHub issues before starting the alpha.3 implementation queue.
-
-### Security: Refresh TLS Dependency / Add Audit Gate
-
-Proposed issue title:
-- `security: refresh rustls-webpki and add cargo audit release gate`
-
-Why it matters:
-- `Cargo.lock` currently resolves `rustls-webpki 0.103.11`.
-- RustSec advisories published in April 2026 identify affected versions fixed in newer `rustls-webpki` releases.
-- The project uses `reqwest` with `rustls-tls`, so TLS verification dependencies are release-critical.
-
-Required work:
-- Update the lockfile so `rustls-webpki` resolves to a fixed version.
-- Install or wire `cargo-audit` in the release gate path.
-- Document audit output in the alpha.3 gate.
-
-Acceptance:
-- `cargo audit` passes or all advisories are explicitly documented as non-applicable.
-- `cargo test --workspace --locked` passes after the lockfile update.
-- `cargo clippy --workspace --all-targets --locked -- -D warnings` passes.
-
-### Docs: Admin Security Contract Alignment
-
-Proposed issue title:
-- `docs(security): align admin plane security contract with implementation`
-
-Why it matters:
-- The admin plane currently exposes local operational endpoints without token authentication.
-- The valid alpha contract is loopback TCP or Unix socket, not authenticated network admin.
-- Release docs should not imply authentication that does not exist.
-
-Required work:
-- Ensure canonical docs describe admin as local-only unless auth is implemented.
-- Do not add authentication to alpha.3 unless the release scope is intentionally expanded.
-- Keep `docs/CONFIG-REFERENCE.md`, `docs/LIMITATIONS.md`, and release notes consistent.
-
-Acceptance:
-- Canonical docs do not claim admin token auth.
-- Admin bind examples stay on `127.0.0.1` or Unix socket paths.
-- Alpha.3 release notes include the local-admin limitation.
+- Merge the release-prep PR after CI confirms the full gate in a loopback-capable environment.
+- Tag `v0.1.0-alpha.3` from updated `main`.
+- Publish the GitHub Release through `.github/workflows/release.yml`.
+- Verify artifacts and checksums.
+- Close `#186`.
 
 ## Alpha.3 Release Sequence
 
-Recommended order:
+Current order:
 
-1. File the two new blocker issues listed above.
-2. Patch TLS dependency and add audit-gate evidence.
-3. Close `#184` tokenizer dispatch.
-4. Close `#185` structured proxy tracing.
-5. Close `#183` CLI help descriptions.
-6. Align canonical admin security docs.
-7. Bump workspace and `penny-cli` versions to `0.1.0-alpha.3`.
-8. Convert `CHANGELOG.md` `[Unreleased]` into `[v0.1.0-alpha.3] - YYYY-MM-DD`.
-9. Add `docs/RELEASE_GATE_v0.1.0-alpha.3.md`.
-10. Add `docs/release-notes/v0.1.0-alpha.3.md`.
-11. Run the standard gate:
+1. [x] File and close security/audit blocker (`#189`).
+2. [x] Close `#184` tokenizer dispatch.
+3. [x] Close `#185` structured proxy tracing.
+4. [x] Close `#183` CLI help descriptions.
+5. [x] Align canonical admin security docs (`#190`).
+6. [x] Bump workspace and `penny-cli` versions to `0.1.0-alpha.3`.
+7. [x] Convert `CHANGELOG.md` `[Unreleased]` into `[v0.1.0-alpha.3] - 2026-06-20`.
+8. [x] Add `docs/RELEASE_GATE_v0.1.0-alpha.3.md`.
+9. [x] Add `docs/release-notes/v0.1.0-alpha.3.md`.
+10. [ ] Run the standard gate:
     - `cargo fmt --all -- --check`
     - `cargo check --workspace --locked`
     - `cargo test --workspace --locked`
     - `cargo clippy --workspace --all-targets --locked -- -D warnings`
-    - `cargo audit`
-12. Tag and publish `v0.1.0-alpha.3`.
-13. Verify release artifacts and checksums.
+    - `cargo audit --ignore RUSTSEC-2023-0071`
+11. [ ] Tag and publish `v0.1.0-alpha.3`.
+12. [ ] Verify release artifacts and checksums.
+13. [ ] Close `#186`.
 
 ## Release Gate Notes
 

--- a/docs/LIMITATIONS.md
+++ b/docs/LIMITATIONS.md
@@ -1,6 +1,6 @@
 # Known Limitations (Alpha)
 
-This list documents current constraints as of April 18, 2026.
+This list documents current constraints as of June 20, 2026.
 
 ## CLI / Product Surface
 

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -5,8 +5,8 @@ This document defines the repeatable process for alpha releases.
 ## Release Gates
 
 - Generic alpha manual checklist: [`docs/ALPHA-MANUAL-CHECKLIST.md`](./ALPHA-MANUAL-CHECKLIST.md)
-- Targeted gate for current cut: [`docs/RELEASE_GATE_v0.1.0-alpha.2.md`](./RELEASE_GATE_v0.1.0-alpha.2.md)
-- Release notes for current cut: [`docs/release-notes/v0.1.0-alpha.2.md`](./release-notes/v0.1.0-alpha.2.md)
+- Targeted gate for current cut: [`docs/RELEASE_GATE_v0.1.0-alpha.3.md`](./RELEASE_GATE_v0.1.0-alpha.3.md)
+- Release notes for current cut: [`docs/release-notes/v0.1.0-alpha.3.md`](./release-notes/v0.1.0-alpha.3.md)
 - Release history reconciliation note: [`docs/release-audit/2026-04-30-release-history-reconciliation.md`](./release-audit/2026-04-30-release-history-reconciliation.md)
 
 ## Scope
@@ -30,14 +30,14 @@ Release workflow file:
 
 Trigger condition:
 
-- push a tag that starts with `v` (example: `v0.1.0-alpha.2`)
+- push a tag that starts with `v` (example: `v0.1.0-alpha.3`)
 
 Manual trigger is also available via `workflow_dispatch`.
 
 ## Cut a Release
 
 1. Ensure `main` is green and synchronized.
-2. Complete the active release gate checklist (`RELEASE_GATE_v0.1.0-alpha.2.md` for alpha.2).
+2. Complete the active release gate checklist (`RELEASE_GATE_v0.1.0-alpha.3.md` for alpha.3).
 3. Update `CHANGELOG.md` and finalize release notes.
 4. Confirm release notes include resolved blocking issues and known limitations link.
 5. Create and push a tag:
@@ -45,8 +45,8 @@ Manual trigger is also available via `workflow_dispatch`.
 ```bash
 git switch main
 git pull --ff-only origin main
-git tag v0.1.0-alpha.2
-git push origin v0.1.0-alpha.2
+git tag v0.1.0-alpha.3
+git push origin v0.1.0-alpha.3
 ```
 
 6. Wait for the `Release` workflow to finish.
@@ -62,7 +62,7 @@ For other versions, replace the tag value and keep the same gate sequence.
 Download one artifact and verify:
 
 ```bash
-shasum -a 256 -c penny-cli-v0.1.0-alpha.2-x86_64-unknown-linux-gnu.sha256
+shasum -a 256 -c penny-cli-v0.1.0-alpha.3-x86_64-unknown-linux-gnu.sha256
 ```
 
 If `shasum` is unavailable, use `sha256sum -c`.
@@ -77,7 +77,7 @@ scripts/install.sh
 
 Supported env vars:
 
-- `PENNY_VERSION` (example: `v0.1.0-alpha.2`)
+- `PENNY_VERSION` (example: `v0.1.0-alpha.3`)
 - `PENNY_INSTALL_DIR` (default: `~/.local/bin`)
 - `PENNY_REPO` (default: `manuelpenazuniga/PennyPrompt`)
 
@@ -90,7 +90,7 @@ curl -fsSL https://raw.githubusercontent.com/manuelpenazuniga/PennyPrompt/main/s
 Pinned version:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/manuelpenazuniga/PennyPrompt/main/scripts/install.sh | PENNY_VERSION=v0.1.0-alpha.2 sh
+curl -fsSL https://raw.githubusercontent.com/manuelpenazuniga/PennyPrompt/main/scripts/install.sh | PENNY_VERSION=v0.1.0-alpha.3 sh
 ```
 
 ## Release Maturity Policy

--- a/docs/RELEASE_GATE_v0.1.0-alpha.3.md
+++ b/docs/RELEASE_GATE_v0.1.0-alpha.3.md
@@ -1,0 +1,141 @@
+# Release Gate: v0.1.0-alpha.3
+
+Objective gate for publishing `v0.1.0-alpha.3` after the alpha.3 hardening scope.
+
+Status: pre-tag candidate. This document records the release-prep gate; publish/artifact verification remains pending until the tag workflow completes.
+
+## 1. Scope Lock
+
+- [x] `#183` merged: CLI help descriptions for root and nested subcommands.
+- [x] `#184` merged: per-model tokenizer dispatch for OpenAI, Anthropic, and fallback models.
+- [x] `#185` merged: structured proxy tracing on the request hot path.
+- [x] `#189` merged: TLS verification dependency refresh and `cargo audit` CI gate.
+- [x] `#190` merged: admin-plane security contract aligned with current local-only implementation.
+- [x] `#196` opened for release-prep docs/version work.
+
+## 2. Version Gate
+
+- [x] Workspace package version is `0.1.0-alpha.3`.
+- [x] `crates/penny-cli/Cargo.toml` version is `0.1.0-alpha.3`.
+- [x] `pennyprompt --version` reports `pennyprompt 0.1.0-alpha.3` from a release build.
+
+Evidence:
+- `cargo build --release -p penny-cli --locked` passed on 2026-06-20.
+- `HOME="$PENNY_RELEASE_HOME" ./target/release/penny-cli --version` returned `pennyprompt 0.1.0-alpha.3`.
+
+## 3. Workspace Quality Gate
+
+Run on the release candidate branch before merge, and again from `main` before tagging if any code changes land after this gate.
+
+- [x] `cargo fmt --all -- --check`
+- [x] `cargo check --workspace --locked`
+- [ ] `cargo test --workspace --locked`
+- [x] `cargo clippy --workspace --all-targets --locked -- -D warnings`
+
+Evidence:
+- Executed locally on 2026-06-20 from `release-alpha3-prep`.
+- `cargo test --workspace --locked` was attempted but the restricted sandbox rejected local TCP binds with `Operation not permitted`.
+- Follow-up command passed for all non-bind tests:
+  - `cargo test --workspace --locked -- --skip check_admin_bind_readiness_accepts_ephemeral_tcp_bind --skip serve_mock_starts_proxy_and_admin_and_shuts_down_cleanly --skip anthropic_error_payload_is_mapped --skip anthropic_non_stream_is_mapped_to_openai_shape --skip anthropic_streaming_sse_is_rewritten_with_usage_chunk --skip openai_error_payload_is_mapped --skip openai_http_429_and_503_are_passthrough --skip openai_non_stream_forwards_payload_and_auth_header --skip openai_parse_failure_is_mapped_to_502 --skip openai_stream_can_arrive_without_usage_for_estimation_fallback --skip openai_stream_preserves_usage_when_present --skip openai_timeout_is_mapped_to_504`
+- Full `cargo test --workspace --locked` remains a CI/main pre-tag requirement where loopback binds are permitted.
+
+## 4. Security Audit Gate
+
+- [x] `cargo audit --ignore RUSTSEC-2023-0071`
+
+Evidence:
+- `RUSTSEC-2023-0071` remains ignored intentionally because `rsa` is present through lockfile metadata for sqlx optional MySQL support, not the active normal dependency graph.
+- CI runs the same audit command.
+- Local sandbox run used the already-present advisory DB without network fetch:
+  - DB path: `$CARGO_AUDIT_DB`
+  - DB revision: `776615bd`
+  - DB commit date: `2026-06-18T13:58:33+02:00`
+  - Command: `cargo audit --db "$CARGO_AUDIT_DB" --no-fetch --no-yanked --ignore RUSTSEC-2023-0071`
+
+## 5. Runtime Acceptance Smoke Tests
+
+Use isolated local state.
+
+Reference command sequence:
+
+```bash
+PENNY_RELEASE_HOME="$(mktemp -d)"
+mkdir -p "$PENNY_RELEASE_HOME/.local/share/pennyprompt"
+
+cargo build --release -p penny-cli --locked
+
+HOME="$PENNY_RELEASE_HOME" ./target/release/penny-cli --version
+HOME="$PENNY_RELEASE_HOME" ./target/release/penny-cli init --preset indie --force
+HOME="$PENNY_RELEASE_HOME" ./target/release/penny-cli prices update
+HOME="$PENNY_RELEASE_HOME" ./target/release/penny-cli --json-log serve --mock --admin-bind 127.0.0.1:8586
+curl -fsS http://127.0.0.1:8586/admin/health
+curl -fsS -X POST http://127.0.0.1:8585/v1/chat/completions \
+  -H 'content-type: application/json' \
+  -d '{"model":"claude-sonnet-4-6","messages":[{"role":"user","content":"hi"}]}'
+HOME="$PENNY_RELEASE_HOME" ./target/release/penny-cli tail --admin-url http://127.0.0.1:8586 --once --limit 20
+```
+
+- [x] `pennyprompt --version` reports alpha.3.
+- [x] `init --preset indie --force` succeeds.
+- [x] `prices update` succeeds and validates default models.
+- [x] `doctor` succeeds in isolated HOME.
+- [ ] `serve --mock --admin-bind 127.0.0.1:8586` starts proxy and admin planes.
+- [ ] `admin/health` returns `200`.
+- [ ] Proxy chat completion path returns `200`.
+- [ ] `tail --once` can consume admin events.
+- [ ] `--json-log` emits structured proxy events.
+
+Evidence:
+- Executed locally on 2026-06-20 from `release-alpha3-prep` with an isolated `$PENNY_RELEASE_HOME`.
+- `init --preset indie --force` created `$PENNY_RELEASE_HOME/.config/pennyprompt/config.toml`.
+- `prices update` output: `imported_entries: 10`, `validated_default_models: 2`.
+- `doctor` exited successfully with config/database OK, 10 active pricebook models, and expected missing provider API keys in isolated local state.
+- TCP bind smoke remains pending because the restricted sandbox rejects local listener creation with `Operation not permitted`.
+
+## 6. Docs Consistency Gate
+
+- [x] `CHANGELOG.md` contains `v0.1.0-alpha.3` notes before tag push.
+- [x] `docs/release-notes/v0.1.0-alpha.3.md` exists.
+- [x] `docs/RELEASE.md` points the active gate and notes links at alpha.3.
+- [x] `docs/GITHUB_BACKLOG.md` reflects `#196` as release prep and `#186` as the remaining publish epic.
+- [x] `docs/CONFIG-REFERENCE.md` and `docs/LIMITATIONS.md` document admin as local-only and unauthenticated in the current alpha.
+- [x] README documents admin TCP as loopback-only and states bearer/admin-token auth is not implemented yet.
+
+## 7. CI and Release Workflow Gate
+
+- [ ] Release-prep PR CI is green.
+- [ ] Tag `v0.1.0-alpha.3` is pushed from updated `main`.
+- [ ] Release workflow publishes at least the minimum artifact set required by `.github/workflows/release.yml`.
+
+Evidence:
+- Pending PR and tag workflow.
+
+## 8. Artifact Verification Gate
+
+After the Release workflow publishes, verify at least one downloaded artifact checksum.
+
+Reference checksum commands:
+
+```bash
+gh release download v0.1.0-alpha.3 \
+  --repo manuelpenazuniga/PennyPrompt \
+  --pattern 'penny-cli-v0.1.0-alpha.3-x86_64-unknown-linux-gnu.tar.gz' \
+  --pattern 'penny-cli-v0.1.0-alpha.3-x86_64-unknown-linux-gnu.sha256'
+
+shasum -a 256 -c penny-cli-v0.1.0-alpha.3-x86_64-unknown-linux-gnu.sha256
+```
+
+- [ ] Release has target archives and per-target `.sha256` files.
+- [ ] `CHECKSUMS.txt` is present.
+- [ ] At least one target checksum verifies locally.
+
+Evidence:
+- Pending tag workflow.
+
+## 9. Publish Decision
+
+- [ ] All pre-tag release-prep boxes above are checked.
+- [ ] `main` is synchronized with `origin/main`.
+- [ ] `v0.1.0-alpha.3` tag pushed.
+- [ ] GitHub Release verified.
+- [ ] `#186` closed after artifact verification.

--- a/docs/release-notes/v0.1.0-alpha.3.md
+++ b/docs/release-notes/v0.1.0-alpha.3.md
@@ -1,0 +1,46 @@
+# PennyPrompt v0.1.0-alpha.3
+
+Publication status: pre-tag candidate for GitHub Release publication (`prerelease: true`, intentional alpha policy).
+
+## Summary
+
+This alpha.3 cut is a hardening release. It does not add new product surface area; it improves correctness, operator visibility, CLI discoverability, security-gate coverage, and release documentation.
+
+## Resolved Issues
+
+- Closes #183: CLI root and nested `--help` output now includes useful command descriptions.
+- Closes #184: token estimation now dispatches by model family instead of applying one OpenAI tokenizer path to every model.
+- Closes #185: proxy request handling now emits structured tracing events suitable for `--json-log` operations.
+- Closes #189: TLS verification dependencies were refreshed and `cargo audit` was added to CI.
+- Closes #190: admin-plane security docs now match the current local-only implementation contract.
+- Closes #196: alpha.3 gate, release notes, changelog, and active-release docs were prepared.
+
+## Validation
+
+Pre-tag validation is tracked in [docs/RELEASE_GATE_v0.1.0-alpha.3.md](../RELEASE_GATE_v0.1.0-alpha.3.md).
+
+Required gate commands:
+
+- `cargo fmt --all -- --check`
+- `cargo check --workspace --locked`
+- `cargo test --workspace --locked`
+- `cargo clippy --workspace --all-targets --locked -- -D warnings`
+- `cargo audit --ignore RUSTSEC-2023-0071`
+
+## Known Limitations
+
+Current alpha limitations are documented in [docs/LIMITATIONS.md](../LIMITATIONS.md).
+
+Important alpha.3 limitation: admin APIs do not implement bearer/admin-token authentication. Use a Unix socket or loopback TCP bind only; do not expose the admin plane to LAN or public networks.
+
+## Artifacts
+
+Expected release assets after the `v0.1.0-alpha.3` tag workflow publishes:
+
+- target archives (`.tar.gz`) for Linux/macOS on `x86_64` + `arm64`
+- per-target SHA-256 files
+- aggregated `CHECKSUMS.txt`
+
+### Artifact provenance
+
+Release artifacts are expected to be built by GitHub Actions from the tag commit. If the `x86_64-apple-darwin` runner is unavailable and requires the documented local backfill path, record the local-build checksum and provenance before closing the release epic.


### PR DESCRIPTION
Closes #196.

Supports #186, but does not close it. The epic should close only after `v0.1.0-alpha.3` is tagged, the GitHub Release publishes, and artifacts/checksums are verified.

## Summary
- Bumps release-facing versions to `0.1.0-alpha.3` for the workspace and `penny-cli`.
- Finalizes `CHANGELOG.md` alpha.3 notes and adds alpha.3 release notes.
- Adds `docs/RELEASE_GATE_v0.1.0-alpha.3.md` with local pre-tag evidence and remaining publish checks.
- Refreshes `docs/GITHUB_BACKLOG.md`, `docs/RELEASE.md`, and the limitations date for the active cut.

## Validation
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo check --workspace --locked`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo audit --db /Users/mpz/.cargo/advisory-db --no-fetch --no-yanked --ignore RUSTSEC-2023-0071`
- `cargo build --release -p penny-cli --locked`
- `HOME=/private/tmp/pennyprompt-alpha3-home ./target/release/penny-cli --version` -> `pennyprompt 0.1.0-alpha.3`
- `HOME=/private/tmp/pennyprompt-alpha3-home ./target/release/penny-cli init --preset indie --force`
- `HOME=/private/tmp/pennyprompt-alpha3-home ./target/release/penny-cli prices update`
- `HOME=/private/tmp/pennyprompt-alpha3-home ./target/release/penny-cli doctor`

## Local caveat
- `cargo test --workspace --locked` was attempted, but this sandbox rejects tests that bind local TCP ports with `Operation not permitted`.
- A follow-up run passed with only the bind-dependent tests skipped; CI should be treated as the full loopback-capable test gate for this PR.
