### PR TITLE
feat(cli): implement run orchestration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1630,9 +1630,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "bytes",
  "getrandom 0.3.4",

--- a/README.md
+++ b/README.md
@@ -300,7 +300,8 @@ pennyprompt [--log-filter <filter>] [--json-log]
 ├── init [--preset indie|team|explore]     Setup wizard
 ├── serve [--mock] [--proxy-bind] [--admin-bind]  Start proxy + admin
 ├── estimate [--model M] [--context-files]  Pre-execution cost estimate
-├── run <agent> [--json]                    Launcher dry-run plan
+├── run <agent> [--execute] [--mock] [--json] -- [args]
+│                                             Launcher plan or local execution
 ├── report
 │   ├── summary [--since] [--by project|model|session]
 │   └── top [--limit N]                     Most expensive requests

--- a/crates/penny-cli/Cargo.toml
+++ b/crates/penny-cli/Cargo.toml
@@ -25,7 +25,7 @@ serde_json = "1"
 sqlx = { version = "0.8", default-features = false, features = ["runtime-tokio-rustls", "sqlite"] }
 tempfile = "3"
 thiserror = "1"
-tokio = { version = "1", features = ["macros", "rt-multi-thread", "net", "signal", "time"] }
+tokio = { version = "1", features = ["macros", "rt-multi-thread", "net", "process", "signal", "time"] }
 toml = "0.8"
 
 [dev-dependencies]

--- a/crates/penny-cli/src/main.rs
+++ b/crates/penny-cli/src/main.rs
@@ -36,6 +36,7 @@ use serde_json::{json, Value};
 use sqlx::{query, Row};
 use tempfile::Builder;
 use thiserror::Error;
+use tokio::process::Command as TokioProcessCommand;
 
 #[cfg(unix)]
 use std::os::{fd::AsRawFd, unix::process::CommandExt};
@@ -109,11 +110,17 @@ enum Commands {
         #[command(subcommand)]
         command: DetectCommands,
     },
-    #[command(about = "preview launcher attribution and runtime wiring (dry-run plan only)")]
+    #[command(about = "run a local agent command through PennyPrompt proxy wiring")]
     Run {
         agent: String,
         #[arg(long, default_value_t = false)]
         execute: bool,
+        #[arg(
+            long,
+            default_value_t = false,
+            help = "Use the bundled mock provider for local launcher smoke tests."
+        )]
+        mock: bool,
         #[arg(long)]
         project_id: Option<String>,
         #[arg(long)]
@@ -122,6 +129,13 @@ enum Commands {
         cwd: Option<PathBuf>,
         #[arg(long, default_value_t = false)]
         json: bool,
+        #[arg(
+            last = true,
+            allow_hyphen_values = true,
+            value_name = "AGENT_ARG",
+            help = "Arguments passed to the agent command after `--`."
+        )]
+        agent_args: Vec<String>,
     },
     #[command(about = "start proxy and admin planes")]
     Serve {
@@ -499,10 +513,12 @@ struct TailCommand {
 struct RunCommand {
     agent: String,
     execute: bool,
+    mock: bool,
     project_id: Option<String>,
     session_id: Option<String>,
     cwd: Option<PathBuf>,
     as_json: bool,
+    agent_args: Vec<String>,
 }
 
 #[derive(Debug, Clone)]
@@ -552,10 +568,14 @@ struct ServePidFileLock {
 struct LaunchPlan {
     mode: String,
     agent: String,
+    agent_args: Vec<String>,
+    mock: bool,
     project_id: String,
     session_id: String,
     cwd: String,
     proxy_bind: String,
+    proxy_url: String,
+    openai_base_url: String,
     admin_socket: String,
     database_path: String,
     config_path: String,
@@ -740,20 +760,24 @@ async fn run(cli: Cli) -> Result<(), CliError> {
         Commands::Run {
             agent,
             execute,
+            mock,
             project_id,
             session_id,
             cwd,
             json,
+            agent_args,
         } => {
             run_launcher(
                 &store,
                 RunCommand {
                     agent,
                     execute,
+                    mock,
                     project_id,
                     session_id,
                     cwd,
                     as_json: json,
+                    agent_args,
                 },
             )
             .await?;
@@ -1339,12 +1363,6 @@ async fn run_estimate(store: &SqliteStore, command: EstimateCommand) -> Result<(
 
 async fn run_launcher(store: &SqliteStore, command: RunCommand) -> Result<(), CliError> {
     let agent = normalize_required_arg(&command.agent, "agent")?;
-    if command.execute {
-        return Err(CliError::Run(
-            "execute mode is not implemented yet. Rerun without --execute for deterministic dry-run output.".to_string(),
-        ));
-    }
-
     let explicit_cwd = command.cwd.is_some();
     let cwd = resolve_launcher_cwd(command.cwd)?;
     let config = load_config(LoadOptions {
@@ -1373,28 +1391,197 @@ async fn run_launcher(store: &SqliteStore, command: RunCommand) -> Result<(), Cl
     let config_path = resolve_user_config_target()
         .map(|path| path.display().to_string())
         .unwrap_or_else(|_| "(unresolved)".to_string());
-    let plan = LaunchPlan {
-        mode: "dry_run".to_string(),
+    let mut plan = build_launch_plan(
+        if command.execute {
+            "execute"
+        } else {
+            "dry_run"
+        },
         agent,
+        command.agent_args,
+        command.mock,
         project_id,
         session_id,
-        cwd: cwd.display().to_string(),
-        proxy_bind: config.server.bind,
-        admin_socket: config.server.admin_socket,
-        database_path: config.server.database_path,
+        &cwd,
+        &config.server.bind,
+        &config.server.admin_socket,
+        &config.server.database_path,
         config_path,
-    };
+    );
+
+    if !command.execute {
+        if command.as_json {
+            println!(
+                "{}",
+                serde_json::to_string_pretty(&plan)
+                    .map_err(|error| CliError::Run(error.to_string()))?
+            );
+        } else {
+            println!("{}", render_launch_plan(&plan));
+        }
+        return Ok(());
+    }
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .map_err(|error| CliError::Run(format!("failed binding launcher proxy: {error}")))?;
+    let local_addr = listener
+        .local_addr()
+        .map_err(|error| CliError::Run(format!("failed resolving launcher proxy bind: {error}")))?;
+    let proxy_bind = local_addr.to_string();
+    plan.proxy_bind = proxy_bind.clone();
+    plan.proxy_url = proxy_url_from_bind(&proxy_bind);
+    plan.openai_base_url = openai_base_url_from_proxy_url(&plan.proxy_url);
 
     if command.as_json {
-        println!(
+        eprintln!(
             "{}",
             serde_json::to_string_pretty(&plan)
                 .map_err(|error| CliError::Run(error.to_string()))?
         );
     } else {
-        println!("{}", render_launch_plan(&plan));
+        eprintln!("{}", render_launch_plan(&plan));
     }
-    Ok(())
+    run_launcher_execute(store, &config, &plan, &cwd, listener).await
+}
+
+#[allow(clippy::too_many_arguments)]
+fn build_launch_plan(
+    mode: &str,
+    agent: String,
+    agent_args: Vec<String>,
+    mock: bool,
+    project_id: String,
+    session_id: String,
+    cwd: &Path,
+    proxy_bind: &str,
+    admin_socket: &str,
+    database_path: &str,
+    config_path: String,
+) -> LaunchPlan {
+    let proxy_url = proxy_url_from_bind(proxy_bind);
+    LaunchPlan {
+        mode: mode.to_string(),
+        agent,
+        agent_args,
+        mock,
+        project_id,
+        session_id,
+        cwd: cwd.display().to_string(),
+        proxy_bind: proxy_bind.to_string(),
+        openai_base_url: openai_base_url_from_proxy_url(&proxy_url),
+        proxy_url,
+        admin_socket: admin_socket.to_string(),
+        database_path: database_path.to_string(),
+        config_path,
+    }
+}
+
+async fn run_launcher_execute(
+    store: &SqliteStore,
+    config: &AppConfig,
+    plan: &LaunchPlan,
+    cwd: &Path,
+    listener: tokio::net::TcpListener,
+) -> Result<(), CliError> {
+    let runtime = build_runtime_provider(config, plan.mock)?;
+    let proxy_state =
+        build_state_from_config(runtime.provider, runtime.models, store.clone(), config)
+            .await
+            .map_err(CliError::Run)?
+            .with_default_attribution(plan.project_id.clone(), plan.session_id.clone());
+    let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel::<()>();
+    let proxy_task = tokio::spawn({
+        async move {
+            penny_proxy::serve_listener_with_state_and_shutdown(listener, proxy_state, async move {
+                let _ = shutdown_rx.await;
+            })
+            .await
+        }
+    });
+
+    if !wait_for_launcher_proxy_ready(&plan.proxy_bind).await {
+        let _ = shutdown_tx.send(());
+        let _ = proxy_task.await;
+        return Err(CliError::Run(format!(
+            "launcher proxy did not become ready at {}",
+            plan.proxy_url
+        )));
+    }
+
+    let status_result = execute_agent_process(plan, cwd).await;
+    let _ = shutdown_tx.send(());
+    let proxy_result = proxy_task
+        .await
+        .map_err(|error| CliError::Run(format!("launcher proxy task join error: {error}")))?;
+    proxy_result.map_err(|error| CliError::Run(format!("launcher proxy error: {error}")))?;
+    let status = status_result?;
+
+    if status.success() {
+        return Ok(());
+    }
+
+    Err(CliError::Run(format!(
+        "agent `{}` exited with {}",
+        plan.agent,
+        format_exit_status(status)
+    )))
+}
+
+async fn execute_agent_process(
+    plan: &LaunchPlan,
+    cwd: &Path,
+) -> Result<std::process::ExitStatus, CliError> {
+    let mut command = TokioProcessCommand::new(&plan.agent);
+    command
+        .args(&plan.agent_args)
+        .current_dir(cwd)
+        .stdin(Stdio::inherit())
+        .stdout(Stdio::inherit())
+        .stderr(Stdio::inherit())
+        .env("PENNY_PROXY_URL", &plan.proxy_url)
+        .env("PENNY_PROJECT_ID", &plan.project_id)
+        .env("PENNY_SESSION_ID", &plan.session_id)
+        .env("PENNY_CWD", &plan.cwd)
+        .env("OPENAI_BASE_URL", &plan.openai_base_url)
+        .env("OPENAI_API_BASE", &plan.openai_base_url);
+
+    if std::env::var_os("OPENAI_API_KEY").is_none() {
+        command.env("OPENAI_API_KEY", "pennyprompt-local-proxy");
+    }
+
+    command
+        .status()
+        .await
+        .map_err(|error| CliError::Run(format!("failed starting agent `{}`: {error}", plan.agent)))
+}
+
+async fn wait_for_launcher_proxy_ready(proxy_bind: &str) -> bool {
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(3);
+    loop {
+        if tcp_connect_ready(proxy_bind).await {
+            return true;
+        }
+        if tokio::time::Instant::now() >= deadline {
+            return false;
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+}
+
+fn proxy_url_from_bind(bind: &str) -> String {
+    format!("http://{}", readiness_connect_target(bind))
+}
+
+fn openai_base_url_from_proxy_url(proxy_url: &str) -> String {
+    format!("{}/v1", proxy_url.trim_end_matches('/'))
+}
+
+fn format_exit_status(status: std::process::ExitStatus) -> String {
+    match status.code() {
+        Some(code) => format!("exit code {code}"),
+        None => "signal termination".to_string(),
+    }
 }
 
 async fn run_serve(store: &SqliteStore, command: ServeCommand) -> Result<(), CliError> {
@@ -2311,17 +2498,28 @@ fn default_project_id_from_cwd(cwd: &Path) -> String {
 
 fn render_launch_plan(plan: &LaunchPlan) -> String {
     format!(
-        "Run launcher plan\n  mode: {}\n  agent: {}\n  project_id: {}\n  session_id: {}\n  cwd: {}\n  proxy_bind: {}\n  admin_socket: {}\n  database_path: {}\n  config_path: {}",
+        "Run launcher plan\n  mode: {}\n  agent: {}\n  agent_args: {}\n  mock: {}\n  project_id: {}\n  session_id: {}\n  cwd: {}\n  proxy_bind: {}\n  proxy_url: {}\n  openai_base_url: {}\n  admin_socket: {}\n  database_path: {}\n  config_path: {}",
         plan.mode,
         plan.agent,
+        render_agent_args(&plan.agent_args),
+        plan.mock,
         plan.project_id,
         plan.session_id,
         plan.cwd,
         plan.proxy_bind,
+        plan.proxy_url,
+        plan.openai_base_url,
         plan.admin_socket,
         plan.database_path,
         plan.config_path
     )
+}
+
+fn render_agent_args(args: &[String]) -> String {
+    if args.is_empty() {
+        return "(none)".to_string();
+    }
+    serde_json::to_string(args).unwrap_or_else(|_| format!("{args:?}"))
 }
 
 async fn run_tail(command: TailCommand) -> Result<(), CliError> {
@@ -4904,10 +5102,14 @@ mod tests {
         let plan = LaunchPlan {
             mode: "dry_run".to_string(),
             agent: "codex".to_string(),
+            agent_args: Vec::new(),
+            mock: false,
             project_id: "my-project".to_string(),
             session_id: "session-auto".to_string(),
             cwd: "/tmp/work".to_string(),
             proxy_bind: "127.0.0.1:8585".to_string(),
+            proxy_url: "http://127.0.0.1:8585".to_string(),
+            openai_base_url: "http://127.0.0.1:8585/v1".to_string(),
             admin_socket: "127.0.0.1:8586".to_string(),
             database_path: "~/.config/pennyprompt/pennyprompt.db".to_string(),
             config_path: "~/.config/pennyprompt/config.toml".to_string(),
@@ -4916,7 +5118,7 @@ mod tests {
         let rendered = render_launch_plan(&plan);
         assert_eq!(
             rendered,
-            "Run launcher plan\n  mode: dry_run\n  agent: codex\n  project_id: my-project\n  session_id: session-auto\n  cwd: /tmp/work\n  proxy_bind: 127.0.0.1:8585\n  admin_socket: 127.0.0.1:8586\n  database_path: ~/.config/pennyprompt/pennyprompt.db\n  config_path: ~/.config/pennyprompt/config.toml"
+            "Run launcher plan\n  mode: dry_run\n  agent: codex\n  agent_args: (none)\n  mock: false\n  project_id: my-project\n  session_id: session-auto\n  cwd: /tmp/work\n  proxy_bind: 127.0.0.1:8585\n  proxy_url: http://127.0.0.1:8585\n  openai_base_url: http://127.0.0.1:8585/v1\n  admin_socket: 127.0.0.1:8586\n  database_path: ~/.config/pennyprompt/pennyprompt.db\n  config_path: ~/.config/pennyprompt/config.toml"
         );
     }
 

--- a/crates/penny-cli/tests/help_output.rs
+++ b/crates/penny-cli/tests/help_output.rs
@@ -39,7 +39,7 @@ fn root_help_lists_descriptions_for_top_level_commands() {
             "list, set, or reset local budget guardrails",
             "estimate token and cost range before running work",
             "inspect or resume detector-paused sessions",
-            "preview launcher attribution and runtime wiring (dry-run plan only)",
+            "run a local agent command through PennyPrompt proxy wiring",
             "start proxy and admin planes",
             "stream admin events from the local control plane",
             "summarize persisted request cost data",
@@ -78,6 +78,13 @@ fn nested_help_lists_descriptions_for_command_groups() {
             &[
                 "summarize requests by project, model, or session",
                 "show highest-cost requests",
+            ][..],
+        ),
+        (
+            ["run", "--help"],
+            &[
+                "Use the bundled mock provider",
+                "Arguments passed to the agent command",
             ][..],
         ),
         (

--- a/crates/penny-cli/tests/run_execute.rs
+++ b/crates/penny-cli/tests/run_execute.rs
@@ -1,0 +1,48 @@
+use std::{path::Path, process::Command};
+
+use tempfile::tempdir;
+
+#[test]
+fn run_execute_mock_launches_agent_with_proxy_env() {
+    let home = tempdir().expect("home temp dir");
+    let workspace = tempdir().expect("workspace temp dir");
+    let db_path = home.path().join("pennyprompt.db");
+    let repo_root = Path::new(env!("CARGO_MANIFEST_DIR")).join("../..");
+    let script = r#"test "$PENNY_PROJECT_ID" = run-smoke &&
+test "$PENNY_SESSION_ID" = session-smoke &&
+case "$PENNY_PROXY_URL" in http://127.0.0.1:*) ;; *) exit 2 ;; esac &&
+case "$OPENAI_BASE_URL" in http://127.0.0.1:*/v1) ;; *) exit 3 ;; esac &&
+test "$OPENAI_API_BASE" = "$OPENAI_BASE_URL" &&
+test "$OPENAI_API_KEY" = pennyprompt-local-proxy"#;
+
+    let output = Command::new(env!("CARGO_BIN_EXE_penny-cli"))
+        .current_dir(repo_root)
+        .env("HOME", home.path())
+        .env_remove("PENNY_CONFIG")
+        .env_remove("OPENAI_API_KEY")
+        .arg("--database")
+        .arg(&db_path)
+        .arg("run")
+        .arg("sh")
+        .arg("--execute")
+        .arg("--mock")
+        .arg("--project-id")
+        .arg("run-smoke")
+        .arg("--session-id")
+        .arg("session-smoke")
+        .arg("--cwd")
+        .arg(workspace.path())
+        .arg("--")
+        .arg("-c")
+        .arg(script)
+        .output()
+        .expect("run penny-cli execute smoke");
+
+    assert!(
+        output.status.success(),
+        "run execute smoke failed: status={:?}\nstdout={}\nstderr={}",
+        output.status.code(),
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}

--- a/crates/penny-proxy/src/lib.rs
+++ b/crates/penny-proxy/src/lib.rs
@@ -123,6 +123,16 @@ impl ProxyState {
         self
     }
 
+    pub fn with_default_attribution(
+        mut self,
+        project_id: impl Into<String>,
+        session_id: impl Into<String>,
+    ) -> Self {
+        self.default_project_id = project_id.into();
+        self.default_session_id = session_id.into();
+        self
+    }
+
     pub fn with_mode(mut self, mode: Mode) -> Self {
         self.mode = mode;
         self
@@ -299,6 +309,17 @@ where
 {
     let addr: SocketAddr = bind.parse()?;
     let listener = TcpListener::bind(addr).await?;
+    serve_listener_with_state_and_shutdown(listener, state, shutdown).await
+}
+
+pub async fn serve_listener_with_state_and_shutdown<F>(
+    listener: TcpListener,
+    state: ProxyState,
+    shutdown: F,
+) -> Result<(), ProxyError>
+where
+    F: Future<Output = ()> + Send + 'static,
+{
     let app = build_router(state);
     axum::serve(listener, app)
         .with_graceful_shutdown(shutdown)
@@ -904,15 +925,21 @@ async fn resolve_attribution(
 
     let project_path_seed = if let Some(project) = &project_override {
         format!("/override/{project}")
+    } else if state.default_project_id != "default" {
+        format!("/override/{}", state.default_project_id)
     } else {
         detect_git_root_from(headers)
             .map(|root| root.to_string_lossy().to_string())
             .unwrap_or_else(|| "default".to_string())
     };
 
-    let fallback_project_id = project_override
-        .clone()
-        .unwrap_or_else(|| project_id_from_seed_path(&project_path_seed));
+    let fallback_project_id = project_override.clone().unwrap_or_else(|| {
+        if state.default_project_id != "default" {
+            state.default_project_id.clone()
+        } else {
+            project_id_from_seed_path(&project_path_seed)
+        }
+    });
     let fallback_session_id = session_override
         .clone()
         .unwrap_or_else(|| state.default_session_id.clone());
@@ -928,6 +955,9 @@ async fn resolve_attribution(
     let session_id = if let Some(session_id) = session_override {
         ensure_session_override_exists(store, &session_id, &project_id).await?;
         session_id
+    } else if state.default_session_id != "session-auto" {
+        ensure_session_override_exists(store, &state.default_session_id, &project_id).await?;
+        state.default_session_id.clone()
     } else {
         match SessionRepo::find_active(store, &project_id, state.session_window_minutes)
             .await
@@ -3238,6 +3268,44 @@ action_on_soft = "warn"
                 .expect("project id");
 
         assert_eq!(project_id, "default");
+    }
+
+    #[tokio::test]
+    async fn explicit_default_attribution_is_used_without_headers() {
+        let store = SqliteStore::connect("sqlite::memory:")
+            .await
+            .expect("create in-memory store");
+        let state = ProxyState::mock_default()
+            .with_store(store.clone())
+            .with_default_attribution("launcher-project", "launcher-session");
+        let app = build_router(state);
+        let request = Request::builder()
+            .method("POST")
+            .uri("/v1/chat/completions")
+            .header(header::CONTENT_TYPE, "application/json")
+            .body(Body::from(
+                json!({
+                    "model": "claude-sonnet-4-6",
+                    "messages": [{"role":"user","content":"launcher attribution"}]
+                })
+                .to_string(),
+            ))
+            .expect("request");
+
+        let response = app.oneshot(request).await.expect("response");
+        let request_id = response
+            .headers()
+            .get(REQUEST_ID_HEADER)
+            .and_then(|v| v.to_str().ok())
+            .expect("request id");
+        let row = sqlx::query("SELECT project_id, session_id FROM requests WHERE id = ?1")
+            .bind(request_id)
+            .fetch_one(store.pool())
+            .await
+            .expect("request row");
+
+        assert_eq!(row.get::<String, _>("project_id"), "launcher-project");
+        assert_eq!(row.get::<String, _>("session_id"), "launcher-session");
     }
 
     #[tokio::test]

--- a/docs/CONFIG-REFERENCE.md
+++ b/docs/CONFIG-REFERENCE.md
@@ -61,6 +61,12 @@ Operational note:
 - `auto_detect_project` (`bool`)
 - `session_window_minutes` (`u32`, must be `> 0`)
 
+Launcher note:
+
+- `pennyprompt run <agent>` uses these settings to resolve project/session context before launching the child process.
+- `run --execute` starts a per-run loopback proxy and passes context through `PENNY_PROJECT_ID`, `PENNY_SESSION_ID`, `PENNY_CWD`, `PENNY_PROXY_URL`, `OPENAI_BASE_URL`, and `OPENAI_API_BASE`.
+- The alpha.4 execution contract is intentionally narrow: agents must use OpenAI-compatible `/v1` HTTP traffic for proxy enforcement. Native agent protocols are outside this release scope.
+
 ## `[providers.<name>]`
 
 - `enabled` (`bool`)

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -80,10 +80,17 @@ alias pp='cargo run -p penny-cli --'
 pp doctor
 ```
 
-Launcher preview (dry-run):
+Launcher preview and execution:
 
 ```bash
 ./target/release/penny-cli run codex
+./target/release/penny-cli run codex --execute -- --help
+```
+
+For a credential-free smoke, use the mock provider:
+
+```bash
+./target/release/penny-cli run sh --execute --mock -- -c 'echo "$OPENAI_BASE_URL"'
 ```
 
 ## 5. Configure Initial Settings

--- a/docs/LIMITATIONS.md
+++ b/docs/LIMITATIONS.md
@@ -1,11 +1,12 @@
 # Known Limitations (Alpha)
 
-This list documents current constraints as of June 20, 2026.
+This list documents current constraints as of June 25, 2026.
 
 ## CLI / Product Surface
 
 - `serve` is available in `penny-cli` for foreground and local background operation.
-- `run <agent>` currently emits deterministic dry-run launch plans; full process orchestration remains a follow-up.
+- `run <agent>` supports deterministic dry-run launch plans and a minimal `--execute` path.
+- `run --execute` is limited to local agents that honor OpenAI-compatible `/v1` base URL environment variables; native agent protocols are outside the current alpha scope.
 - Some outputs are operator-focused and intentionally minimal (not final UX polish).
 
 ## Pricebook Update

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -123,7 +123,7 @@ Resume a paused session:
 ./target/release/penny-cli detect resume <session_id>
 ```
 
-## 8. Launcher Plan Preview (post-alpha foundation)
+## 8. Launcher Execution
 
 Preview launcher attribution and runtime wiring:
 
@@ -132,10 +132,25 @@ Preview launcher attribution and runtime wiring:
 ./target/release/penny-cli run codex --json
 ```
 
+Execute a local agent command through a temporary PennyPrompt proxy:
+
+```bash
+./target/release/penny-cli run codex --execute -- --help
+```
+
+Smoke the launcher without provider credentials:
+
+```bash
+./target/release/penny-cli run sh --execute --mock -- -c 'echo "$OPENAI_BASE_URL"'
+```
+
 Notes:
 
-- current behavior is dry-run plan output only
+- without `--execute`, `run` remains a deterministic dry-run plan
+- `--execute` starts a per-run loopback proxy, sets `OPENAI_BASE_URL` / `OPENAI_API_BASE`, and launches the agent process
+- the alpha.4 launcher contract is OpenAI-compatible `/v1` agent traffic; native Anthropic CLI protocol routing is not claimed
 - use `--project-id` / `--session-id` to override detected defaults
+- process startup failures are reported by `pennyprompt run`; budget and provider failures are returned through the proxy to the agent
 
 ## Expected First Outcomes
 


### PR DESCRIPTION
## Summary
- adds a minimal real execution path for `pennyprompt run <agent> --execute`
- starts a per-run loopback proxy, wires OpenAI-compatible env vars, and launches the local agent process
- keeps deterministic dry-run output, adds `--mock` smoke support, and documents the alpha.4 execution contract
- lets launcher-created proxy state attribute requests to the resolved project/session without requiring agent-supplied headers
- updates `quinn-proto` from 0.11.14 to 0.11.15 after CI cargo-audit flagged `RUSTSEC-2026-0185`

## Validation
- `cargo fmt --all -- --check`
- `cargo check --workspace --locked`
- `cargo test -p penny-cli --locked`
- `HOME=/private/tmp/pennyprompt-proxy-test-home RUSTUP_HOME=/Users/mpz/.rustup CARGO_HOME=/Users/mpz/.cargo cargo test -p penny-proxy --locked`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo audit --ignore RUSTSEC-2023-0071`
- `HOME=/private/tmp/pennyprompt-workspace-test-home RUSTUP_HOME=/Users/mpz/.rustup CARGO_HOME=/Users/mpz/.cargo cargo test --workspace --locked` (rerun elevated because the sandbox blocks loopback binds)

Closes #202.